### PR TITLE
cluster-autoscaler/cache: ignore potential nil pointers

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling.go
@@ -51,6 +51,12 @@ func (m autoScalingWrapper) populateLaunchConfigurationInstanceTypeCache(autosca
 	var launchConfigToQuery []*string
 
 	for _, asg := range autoscalingGroups {
+		if asg == nil {
+			continue
+		}
+		if asg.LaunchConfigurationName == nil {
+			continue
+		}
 		i, ok := m.launchConfigurationInstanceTypeCache[*asg.LaunchConfigurationName]
 		if ok {
 			launchToInstanceType[*asg.LaunchConfigurationName] = i


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x176d90f]

goroutine 149 [running]:
k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws.autoScalingWrapper.populateLaunchConfigurationInstanceTypeCache(0x36e7fa0, 0xc00067e0c0, 0x0, 0xc00251fef0, 0xc02d670000, 0x3ee, 0x400, 0x0, 0x0)
	/go/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/auto_scaling.go:54 +0x18f
k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws.(*asgCache).regenerate(0xc000712480, 0x0, 0x0)
	/go/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go:369 +0x2f4
k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws.(*AwsManager).forceRefresh(0xc002018dc0, 0xc002018dc0, 0x0)
	/go/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws_manager.go:254 +0x44
k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws.createAWSManagerInternal(0x0, 0x0, 0x0, 0x0, 0x0, 0xc000456910, 0x1, 0x1, 0xc0020eaa40, 0xc0020eaa10, ...)
	/go/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws_manager.go:217 +0x396
k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws.CreateAwsManager(...)
	/go/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws_manager.go:241
k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws.BuildAWS(0xa, 0x3fdccccccccccccd, 0x3fe0000000000000, 0x8bb2c97000, 0x1176592e000, 0x0, 0x1e84800, 0x0, 0xf4240000000000, 0x0, ...)
	/go/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go:346 +0xeb
k8s.io/autoscaler/cluster-autoscaler/cloudprovider/builder.buildCloudProvider(0xa, 0x3fdccccccccccccd, 0x3fe0000000000000, 0x8bb2c97000, 0x1176592e000, 0x0, 0x1e84800, 0x0, 0xf4240000000000, 0x0, ...)
	/go/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/builder/builder_all.go:53 +0x1a1
k8s.io/autoscaler/cluster-autoscaler/cloudprovider/builder.NewCloudProvider(0xa, 0x3fdccccccccccccd, 0x3fe0000000000000, 0x8bb2c97000, 0x1176592e000, 0x0, 0x1e84800, 0x0, 0xf4240000000000, 0x0, ...)
	/go/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/builder/cloud_provider_builder.go:45 +0x1af
k8s.io/autoscaler/cluster-autoscaler/core.initializeDefaultOptions(0xc0020eb860, 0x18, 0x0)
	/go/src/k8s.io/autoscaler/cluster-autoscaler/core/autoscaler.go:96 +0x2ef
k8s.io/autoscaler/cluster-autoscaler/core.NewAutoscaler(0xa, 0x3fdccccccccccccd, 0x3fe0000000000000, 0x8bb2c97000, 0x1176592e000, 0x0, 0x1e84800, 0x0, 0xf4240000000000, 0x0, ...)
	/go/src/k8s.io/autoscaler/cluster-autoscaler/core/autoscaler.go:64 +0x43
main.buildAutoscaler(0x0, 0x0, 0x0, 0x0)
	/go/src/k8s.io/autoscaler/cluster-autoscaler/main.go:309 +0x279
main.run(0xc000466f50)
	/go/src/k8s.io/autoscaler/cluster-autoscaler/main.go:315 +0x39
main.main.func2(0x36bc0a0, 0xc002d420c0)
	/go/src/k8s.io/autoscaler/cluster-autoscaler/main.go:412 +0x2a
created by k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/client-go/tools/leaderelection.(*LeaderElector).Run
	/go/src/k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go:206 +0x132
```