### PR TITLE
Support Pods without explicit resources requests or limits

### DIFF
--- a/cluster-autoscaler/core/filter_out_schedulable.go
+++ b/cluster-autoscaler/core/filter_out_schedulable.go
@@ -91,6 +91,14 @@ func (filterOutSchedulablePodListProcessor) Process(
 				volumes = append(volumes, vol)
 				continue
 			}
+
+			if len(po.Spec.Containers[0].Resources.Requests) == 0 {
+				po.Spec.Containers[0].Resources.Requests = apiv1.ResourceList{}
+			}
+			if len(po.Spec.Containers[0].Resources.Limits) == 0 {
+				po.Spec.Containers[0].Resources.Limits = apiv1.ResourceList{}
+			}
+
 			po.Spec.Containers[0].Resources.Requests["storageClass/local-data"] = *resource.NewQuantity(1, resource.DecimalSI)
 			po.Spec.Containers[0].Resources.Limits["storageClass/local-data"] = *resource.NewQuantity(1, resource.DecimalSI)
 		}


### PR DESCRIPTION
A pod might not specify resources `Requests` or `Limits`; in which
case those apiv1.ResourceList maps are uninitialised.

We should ensure both those `ResourceRequirements` fields are
initialised before appending our "storageClass/local-data" resource.

Else, we crash with a 
```
panic: assignment to entry in nil map
```