### PR TITLE
Azure support

### DIFF
--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -657,7 +657,7 @@ The following startup parameters are supported for cluster autoscaler:
 | `ok-total-unready-count` | Number of allowed unready nodes, irrespective of max-total-unready-percentage  | 3
 | `max-node-provision-time` | Maximum time CA waits for node to be provisioned | 15 minutes
 | `nodes` | sets min,max size and other configuration data for a node group in a format accepted by cloud provider. Can be used multiple times. Format: <min>:<max>:<other...> | ""
-| `node-group-auto-discovery` | One or more definition(s) of node group auto-discovery.<br>A definition is expressed `<name of discoverer>:[<key>[=<value>]]`<br>The `aws` and `gce` cloud providers are currently supported. AWS matches by ASG tags, e.g. `asg:tag=tagKey,anotherTagKey`<br>GCE matches by IG name prefix, and requires you to specify min and max nodes per IG, e.g. `mig:namePrefix=pfx,min=0,max=10`<br>Can be used multiple times | ""
+| `node-group-auto-discovery` | One or more definition(s) of node group auto-discovery.<br>A definition is expressed `<name of discoverer>:[<key>[=<value>]]`<br>The `aws`, `gce`, and `azure` cloud providers are currently supported. AWS matches by ASG tags, e.g. `asg:tag=tagKey,anotherTagKey`<br>GCE matches by IG name prefix, and requires you to specify min and max nodes per IG, e.g. `mig:namePrefix=pfx,min=0,max=10`<br> Azure matches by tags on VMSS, e.g. `label:foo=bar`, and will auto-detect `min` and `max` tags on the VMSS to set scaling limits.<br>Can be used multiple times | ""
 | `estimator` | Type of resource estimator to be used in scale up | binpacking
 | `expander` | Type of node group expander to be used in scale up.  | random
 | `write-status-configmap` | Should CA write status information to a configmap  | true

--- a/cluster-autoscaler/cloudprovider/azure/README.md
+++ b/cluster-autoscaler/cloudprovider/azure/README.md
@@ -73,6 +73,8 @@ Make a copy of [cluster-autoscaler-vmss.yaml](examples/cluster-autoscaler-vmss.y
 
 > **_NOTE_**: Use a command such as `echo $CLIENT_ID | base64` to encode each of the fields above.
 
+> **_NOTE_** (optional) to specify the TTL of VMSS ASG cache to prevent throttling issue, please provide the env `AZURE_ASG_CACHE_TTL` in seconds which is set 900s by default.
+
 In the `cluster-autoscaler` spec, find the `image:` field and replace `{{ ca_version }}` with a specific cluster autoscaler release.
 
 Below that, in the `command:` section, update the `--nodes=` arguments to reference your node limits and VMSS name. For example, if node pool "k8s-nodepool-1-vmss" should scale from 1 to 10 nodes:

--- a/cluster-autoscaler/cloudprovider/azure/README.md
+++ b/cluster-autoscaler/cloudprovider/azure/README.md
@@ -132,7 +132,8 @@ Make a copy of [cluster-autoscaler-standard-master.yaml](examples/cluster-autosc
 
 In the `cluster-autoscaler` spec, find the `image:` field and replace `{{ ca_version }}` with a specific cluster autoscaler release.
 
-Below that, in the `command:` section, update the `--nodes=` arguments to reference your node limits and node pool name. For example, if node pool "k8s-nodepool-1" should scale from 1 to 10 nodes:
+Below that, in the `command:` section, update the `--nodes=` arguments to reference your node limits and node pool name (tips: node pool name is NOT availability set name, e.g., the corresponding node pool name of the availability set 
+`agentpool1-availabilitySet-xxxxxxxx` would be `agentpool1`). For example, if node pool "k8s-nodepool-1" should scale from 1 to 10 nodes:
 
 ```yaml
         - --nodes=1:10:k8s-nodepool-1

--- a/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
@@ -28,11 +28,11 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2017-05-10/resources"
 	azStorage "github.com/Azure/azure-sdk-for-go/storage"
 	"github.com/Azure/go-autorest/autorest/to"
-	"k8s.io/klog"
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
+	"k8s.io/klog"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 )
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_cache.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cache.go
@@ -17,7 +17,6 @@ limitations under the License.
 package azure
 
 import (
-	"fmt"
 	"reflect"
 	"regexp"
 	"strings"
@@ -153,27 +152,12 @@ func (m *asgCache) FindForInstance(instance *azureRef, vmType string) (cloudprov
 		}
 	}
 
-	klog.V(4).Infof("FindForInstance: cache before refresh %v", m.instanceToAsg)
-
 	// Look up caches for the instance.
+	klog.V(4).Infof("FindForInstance: attempting to retrieve instance %v from cache", m.instanceToAsg)
 	if asg := m.getInstanceFromCache(inst.Name); asg != nil {
-		klog.V(4).Infof("FindForInstance: returns before refresh, asg: %s", asg.Id())
+		klog.V(4).Infof("FindForInstance: found asg %s in cache", asg.Id())
 		return asg, nil
 	}
-
-	// Not found, regenerate the cache and try again.
-	if err := m.regenerate(); err != nil {
-		klog.Errorf("FindForInstance: error while looking for ASG for instance %q, error: %v", instance.Name, err)
-		return nil, fmt.Errorf("error while looking for ASG for instance %q, error: %v", instance.Name, err)
-	}
-
-	klog.V(4).Infof("FindForInstance: cache after refresh %v", m.instanceToAsg)
-
-	if asg := m.getInstanceFromCache(inst.Name); asg != nil {
-		klog.V(4).Infof("FindForInstance: returns after refresh, asg: %s", asg.Id())
-		return asg, nil
-	}
-
 	klog.V(4).Infof("FindForInstance: Couldn't find NodeGroup of instance %q", inst)
 	return nil, nil
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_cache.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cache.go
@@ -174,7 +174,7 @@ func (m *asgCache) FindForInstance(instance *azureRef, vmType string) (cloudprov
 		return asg, nil
 	}
 
-	klog.Warningf("FindForInstance: Couldn't find NodeGroup of instance %q", inst)
+	klog.V(4).Infof("FindForInstance: Couldn't find NodeGroup of instance %q", inst)
 	return nil, nil
 }
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package azure
 
 import (
+	"fmt"
 	"io"
 	"os"
 
@@ -91,15 +92,16 @@ func (azure *AzureCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 
 // NodeGroupForNode returns the node group for the given node.
 func (azure *AzureCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+	klog.V(6).Infof("NodeGroupForNode: starts")
 	if node.Spec.ProviderID == "" {
-		klog.V(6).Infof("Skipping to search for node group for the node '%s'. Because doesn't have spec.ProviderID.\n", node.ObjectMeta.Name)
-		return nil, nil
+		return nil, fmt.Errorf("NodeGroupForNode: provider ID for node %s is not found", node.Name)
 	}
 	klog.V(6).Infof("Searching for node group for the node: %s\n", node.Spec.ProviderID)
 	ref := &azureRef{
 		Name: node.Spec.ProviderID,
 	}
 
+	klog.V(6).Infof("NodeGroupForNode: ref.Name %s", ref.Name)
 	return azure.azureManager.GetAsgForInstance(ref)
 }
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
@@ -152,7 +152,7 @@ func BuildAzure(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscov
 	if opts.CloudConfig != "" {
 		klog.Infof("Creating Azure Manager using cloud-config file: %v", opts.CloudConfig)
 		var err error
-		config, err := os.Open(opts.CloudConfig)
+		config, err = os.Open(opts.CloudConfig)
 		if err != nil {
 			klog.Fatalf("Couldn't open cloud provider configuration %s: %#v", opts.CloudConfig, err)
 		}

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
@@ -29,6 +29,8 @@ import (
 )
 
 func newTestAzureManager(t *testing.T) *AzureManager {
+	vmssName := "test-asg"
+	var vmssCapacity int64 = 3
 	manager := &AzureManager{
 		env:                  azure.PublicCloud,
 		explicitlyConfigured: make(map[string]bool),
@@ -48,11 +50,21 @@ func newTestAzureManager(t *testing.T) *AzureManager {
 				FakeStore: make(map[string]map[string]compute.VirtualMachine),
 			},
 			virtualMachineScaleSetsClient: &VirtualMachineScaleSetsClientMock{
-				FakeStore: make(map[string]map[string]compute.VirtualMachineScaleSet),
+				FakeStore: map[string]map[string]compute.VirtualMachineScaleSet{
+					"test": map[string]compute.VirtualMachineScaleSet{
+						"test-asg": compute.VirtualMachineScaleSet{
+							Name: &vmssName,
+							Sku: &compute.Sku{
+								Capacity: &vmssCapacity,
+							},
+						},
+					},
+				},
 			},
 			virtualMachineScaleSetVMsClient: &VirtualMachineScaleSetVMsClientMock{},
 		},
 	}
+
 	cache, error := newAsgCache()
 	assert.NoError(t, error)
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
@@ -65,7 +65,7 @@ func newTestAzureManager(t *testing.T) *AzureManager {
 		},
 	}
 
-	cache, error := newAsgCache()
+	cache, error := newAsgCache(int64(defaultAsgCacheTTL))
 	assert.NoError(t, error)
 
 	manager.asgCache = cache

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
@@ -120,6 +120,8 @@ func TestNodeGroupForNode(t *testing.T) {
 			ProviderID: "azure://" + fakeVirtualMachineScaleSetVMID,
 		},
 	}
+	// refresh cache
+	provider.azureManager.regenerateCache()
 	group, err := provider.NodeGroupForNode(node)
 	assert.NoError(t, err)
 	assert.NotNil(t, group, "Group should not be nil")

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager.go
@@ -61,10 +61,6 @@ var validLabelAutoDiscovererKeys = strings.Join([]string{
 type labelAutoDiscoveryConfig struct {
 	// Key-values to match on.
 	Selector map[string]string
-	// MinSize specifies the minimum size for all MIGs that match Re.
-	MinSize int
-	// MaxSize specifies the maximum size for all MIGs that match Re.
-	MaxSize int
 }
 
 // AzureManager handles Azure communication and data caching.
@@ -433,7 +429,10 @@ func (m *AzureManager) listScaleSets(filter []labelAutoDiscoveryConfig) (asgs []
 				return asgs, fmt.Errorf("invalid minimum size specified for vmss: %s", err)
 			}
 		} else {
-			return asgs, fmt.Errorf("no minimum size specified for vmss: %s", err)
+			return asgs, fmt.Errorf("no minimum size specified for vmss: %s", *scaleSet.Name)
+		}
+		if spec.MinSize < 0 {
+			return asgs, fmt.Errorf("minimum size must be a non-negative number of nodes")
 		}
 		if val, ok := scaleSet.Tags["max"]; ok {
 			if maxSize, err := strconv.Atoi(*val); err == nil {
@@ -442,7 +441,7 @@ func (m *AzureManager) listScaleSets(filter []labelAutoDiscoveryConfig) (asgs []
 				return asgs, fmt.Errorf("invalid maximum size specified for vmss: %s", err)
 			}
 		} else {
-			return asgs, fmt.Errorf("no maximum size specified for vmss: %s", err)
+			return asgs, fmt.Errorf("no maximum size specified for vmss: %s", *scaleSet.Name)
 		}
 		if spec.MaxSize < 1 {
 			return asgs, fmt.Errorf("maximum size must be greater than 1 node")
@@ -507,8 +506,6 @@ func parseLabelAutoDiscoverySpecs(o cloudprovider.NodeGroupDiscoveryOptions) ([]
 func parseLabelAutoDiscoverySpec(spec string) (labelAutoDiscoveryConfig, error) {
 	cfg := labelAutoDiscoveryConfig{
 		Selector: make(map[string]string),
-		MinSize:  1,
-		MaxSize:  -1,
 	}
 
 	tokens := strings.Split(spec, ":")
@@ -525,31 +522,11 @@ func parseLabelAutoDiscoverySpec(spec string) (labelAutoDiscoveryConfig, error) 
 		if len(kv) != 2 {
 			return cfg, fmt.Errorf("invalid key=value pair %s", kv)
 		}
-
 		k, v := kv[0], kv[1]
-
-		switch k {
-		case labelAutoDiscovererKeyMinNodes:
-			if minSize, err := strconv.Atoi(v); err == nil {
-				cfg.MinSize = minSize
-			} else {
-				return cfg, fmt.Errorf("invalid minimum nodes: %s", v)
-			}
-		case labelAutoDiscovererKeyMaxNodes:
-			if maxSize, err := strconv.Atoi(v); err == nil {
-				cfg.MaxSize = maxSize
-			} else {
-				return cfg, fmt.Errorf("invalid maximum nodes: %s", v)
-			}
-		default:
-			cfg.Selector[k] = v
+		if k == "" || v == "" {
+			return cfg, fmt.Errorf("empty value not allowed in key=value tag pairs")
 		}
-	}
-	if cfg.MaxSize < 1 {
-		return cfg, fmt.Errorf("maximum size must be greater than 1 node")
-	}
-	if cfg.MaxSize < cfg.MinSize {
-		return cfg, fmt.Errorf("maximum size must be greater than minimum size")
+		cfg.Selector[k] = v
 	}
 	return cfg, nil
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager.go
@@ -289,8 +289,13 @@ func (m *AzureManager) Refresh() error {
 }
 
 func (m *AzureManager) forceRefresh() error {
+	// TODO: Refactor some of this logic out of forceRefresh and
+	// consider merging the list call with the Nodes() call
 	if err := m.fetchAutoAsgs(); err != nil {
 		klog.Errorf("Failed to fetch ASGs: %v", err)
+	}
+	if err := m.regenerateCache(); err != nil {
+		klog.Errorf("Failed to regenerate ASG cache: %v", err)
 		return err
 	}
 	m.lastRefresh = time.Now()

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager.go
@@ -17,15 +17,16 @@ limitations under the License.
 package azure
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/Azure/go-autorest/autorest/azure"
-	"gopkg.in/gcfg.v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
 	"k8s.io/klog"
@@ -124,12 +125,16 @@ func (c *Config) TrimSpace() {
 // CreateAzureManager creates Azure Manager object to work with Azure.
 func CreateAzureManager(configReader io.Reader, discoveryOpts cloudprovider.NodeGroupDiscoveryOptions) (*AzureManager, error) {
 	var err error
-	var cfg Config
+	cfg := &Config{}
 
 	if configReader != nil {
-		if err := gcfg.ReadInto(&cfg, configReader); err != nil {
-			klog.Errorf("Couldn't read config: %v", err)
-			return nil, err
+		body, err := ioutil.ReadAll(configReader)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read config: %v", err)
+		}
+		err = json.Unmarshal(body, cfg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal config body: %v", err)
 		}
 	} else {
 		cfg.Cloud = os.Getenv("ARM_CLOUD")
@@ -191,20 +196,20 @@ func CreateAzureManager(configReader io.Reader, discoveryOpts cloudprovider.Node
 		}
 	}
 
-	if err := validateConfig(&cfg); err != nil {
+	if err := validateConfig(cfg); err != nil {
 		return nil, err
 	}
 
 	klog.Infof("Starting azure manager with subscription ID %q", cfg.SubscriptionID)
 
-	azClient, err := newAzClient(&cfg, &env)
+	azClient, err := newAzClient(cfg, &env)
 	if err != nil {
 		return nil, err
 	}
 
 	// Create azure manager.
 	manager := &AzureManager{
-		config:               &cfg,
+		config:               cfg,
 		env:                  env,
 		azClient:             azClient,
 		explicitlyConfigured: make(map[string]bool),

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager.go
@@ -100,6 +100,9 @@ type Config struct {
 	ClusterName string `json:"clusterName" yaml:"clusterName"`
 	//Config only for AKS
 	NodeResourceGroup string `json:"nodeResourceGroup" yaml:"nodeResourceGroup"`
+
+	// ASG cache TTL in seconds
+	AsgCacheTTL int64 `json:"asgCacheTTL" yaml:"asgCacheTTL"`
 }
 
 // TrimSpace removes all leading and trailing white spaces.
@@ -149,6 +152,13 @@ func CreateAzureManager(configReader io.Reader, discoveryOpts cloudprovider.Node
 				return nil, err
 			}
 		}
+
+		if asgCacheTTL := os.Getenv("AZURE_ASG_CACHE_TTL"); asgCacheTTL != "" {
+			cfg.AsgCacheTTL, err = strconv.ParseInt(asgCacheTTL, 10, 0)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse AZURE_ASG_CACHE_TTL %q: %v", asgCacheTTL, err)
+			}
+		}
 	}
 	cfg.TrimSpace()
 
@@ -166,6 +176,10 @@ func CreateAzureManager(configReader io.Reader, discoveryOpts cloudprovider.Node
 		}
 
 		cfg.DeploymentParameters = parameters
+	}
+
+	if cfg.AsgCacheTTL == 0 {
+		cfg.AsgCacheTTL = int64(defaultAsgCacheTTL)
 	}
 
 	// Defaulting env to Azure Public Cloud.
@@ -196,7 +210,7 @@ func CreateAzureManager(configReader io.Reader, discoveryOpts cloudprovider.Node
 		explicitlyConfigured: make(map[string]bool),
 	}
 
-	cache, err := newAsgCache()
+	cache, err := newAsgCache(cfg.AsgCacheTTL)
 	if err != nil {
 		return nil, err
 	}

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+)
+
+const validAzureCfg = `{
+	"cloud": "AzurePublicCloud",
+	"tenantId": "fakeId",
+	"subscriptionId": "fakeId",
+	"aadClientId": "fakeId",
+	"aadClientSecret": "fakeId",
+	"resourceGroup": "fakeId",
+	"location": "southeastasia",
+	"subnetName": "fakeName",
+	"securityGroupName": "fakeName",
+	"vnetName": "fakeName",
+	"routeTableName": "fakeName",
+	"primaryAvailabilitySetName": "fakeName",
+	"asgCacheTTL": 900}`
+
+const invalidAzureCfg = `{{}"cloud": "AzurePublicCloud",}`
+
+func TestCreateAzureManagerValidConfig(t *testing.T) {
+	manager, err := CreateAzureManager(strings.NewReader(validAzureCfg), cloudprovider.NodeGroupDiscoveryOptions{})
+
+	expectdConfig := &Config{
+		Cloud:           "AzurePublicCloud",
+		TenantID:        "fakeId",
+		SubscriptionID:  "fakeId",
+		ResourceGroup:   "fakeId",
+		VMType:          "vmss",
+		AADClientID:     "fakeId",
+		AADClientSecret: "fakeId",
+		AsgCacheTTL:     900,
+	}
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectdConfig, manager.config, "unexpected azure manager configuration")
+}
+
+func TestCreateAzureManagerInvalidConfig(t *testing.T) {
+	_, err := CreateAzureManager(strings.NewReader(invalidAzureCfg), cloudprovider.NodeGroupDiscoveryOptions{})
+	assert.Error(t, err, "failed to unmarshal config body")
+}

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -192,16 +192,19 @@ func (scaleSet *ScaleSet) getCurSize() (int64, error) {
 		}
 		return -1, err
 	}
-	klog.V(5).Infof("Getting scale set (%q) capacity: %d\n", scaleSet.Name, *set.Sku.Capacity)
 
-	if scaleSet.curSize != *set.Sku.Capacity {
+	vmssSizeMutex.Lock()
+	curSize := *set.Sku.Capacity
+	vmssSizeMutex.Unlock()
+
+	klog.V(5).Infof("Getting scale set (%q) capacity: %d\n", scaleSet.Name, curSize)
+
+	if scaleSet.curSize != curSize {
 		// Invalidate the instance cache if the capacity has changed.
 		scaleSet.invalidateInstanceCache()
 	}
 
-	vmssSizeMutex.Lock()
-	scaleSet.curSize = *set.Sku.Capacity
-	vmssSizeMutex.Unlock()
+	scaleSet.curSize = curSize
 	scaleSet.lastSizeRefresh = time.Now()
 	return scaleSet.curSize, nil
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -215,12 +215,14 @@ func (scaleSet *ScaleSet) updateVMSSCapacity(size int64) {
 	var isSuccess bool
 	var err error
 
+	scaleSet.sizeMutex.Lock()
+	defer scaleSet.sizeMutex.Unlock()
+
 	defer func() {
 		if err != nil {
 			klog.Errorf("Failed to update the capacity for vmss %s with error %v, invalidate the cache so as to get the real size from API", scaleSet.Name, err)
 			// Invalidate the VMSS size cache in order to fetch the size from the API.
-			scaleSet.sizeMutex.Lock()
-			defer scaleSet.sizeMutex.Unlock()
+
 			scaleSet.lastSizeRefresh = time.Now().Add(-1 * vmssSizeRefreshPeriod)
 		}
 	}()

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -100,6 +100,9 @@ func TestBelongs(t *testing.T) {
 
 	scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
 	assert.True(t, ok)
+	// TODO: this should call manager.Refresh() once the fetchAutoASG
+	// logic is refactored out
+	provider.azureManager.regenerateCache()
 
 	invalidNode := &apiv1.Node{
 		Spec: apiv1.NodeSpec{
@@ -129,6 +132,9 @@ func TestDeleteNodes(t *testing.T) {
 	}
 	scaleSetClient.On("DeleteInstances", mock.Anything, "test-asg", mock.Anything, mock.Anything).Return(response, nil)
 	manager.azClient.virtualMachineScaleSetsClient = scaleSetClient
+	// TODO: this should call manager.Refresh() once the fetchAutoASG
+	// logic is refactored out
+	manager.regenerateCache()
 
 	resourceLimiter := cloudprovider.NewResourceLimiter(
 		map[string]int64{cloudprovider.ResourceNameCores: 1, cloudprovider.ResourceNameMemory: 10000000},
@@ -139,6 +145,9 @@ func TestDeleteNodes(t *testing.T) {
 	registered := manager.RegisterAsg(
 		newTestScaleSet(manager, "test-asg"))
 	assert.True(t, registered)
+	// TODO: this should call manager.Refresh() once the fetchAutoASG
+	// logic is refactored out
+	manager.regenerateCache()
 
 	node := &apiv1.Node{
 		Spec: apiv1.NodeSpec{
@@ -175,6 +184,9 @@ func TestScaleSetNodes(t *testing.T) {
 	provider := newTestProvider(t)
 	registered := provider.azureManager.RegisterAsg(
 		newTestScaleSet(provider.azureManager, "test-asg"))
+	// TODO: this should call manager.Refresh() once the fetchAutoASG
+	// logic is refactored out
+	provider.azureManager.regenerateCache()
 	assert.True(t, registered)
 	assert.Equal(t, len(provider.NodeGroups()), 1)
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_util.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_util.go
@@ -37,7 +37,6 @@ import (
 
 	"golang.org/x/crypto/pkcs12"
 
-	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/client-go/pkg/version"
 	"k8s.io/klog"
 )
@@ -494,7 +493,7 @@ func GetVMNameIndex(osType compute.OperatingSystemTypes, vmName string) (int, er
 	return agentIndex, nil
 }
 
-func matchDiscoveryConfig(labels map[string]*string, configs []cloudprovider.LabelAutoDiscoveryConfig) bool {
+func matchDiscoveryConfig(labels map[string]*string, configs []labelAutoDiscoveryConfig) bool {
 	if len(configs) == 0 {
 		return false
 	}


### PR DESCRIPTION
Cherry picked changes (from upstream/master) required to:
* Retrieve secrets from the cloud config file instead of env vars
* Be gentle on Azure Scale Set API endpoints. At least, don't trigger rate limits immediately.
* Actually scale up and down tagged scale sets (autodiscovery was broken)

Those commits are exclusively targeting `cloudprovider/azure` (save for a FAQ.md change): they shouldn't affect CA running on other cloud providers:
```
$ git diff --stat datadog/datadog-master..
 cluster-autoscaler/FAQ.md                                           |   2 +-
 cluster-autoscaler/cloudprovider/azure/README.md                    |   5 ++++-
 cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go          |  41 +++++++++++++++++++++++++++++++++++++----
 cluster-autoscaler/cloudprovider/azure/azure_cache.go               |  31 ++++++++++++++++---------------
 cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go      |   8 +++++---
 cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go |  18 ++++++++++++++++--
 cluster-autoscaler/cloudprovider/azure/azure_manager.go             | 142 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++---------------
 cluster-autoscaler/cloudprovider/azure/azure_manager_test.go        |  65 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 cluster-autoscaler/cloudprovider/azure/azure_scale_set.go           |  84 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++------------------------
 cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go      |  12 ++++++++++++
 cluster-autoscaler/cloudprovider/azure/azure_util.go                |   3 +--
 11 files changed, 344 insertions(+), 67 deletions(-)
```

Here's the 13 cherry-picked patchs list, with original/upstream commits ids (as cherry picking mangle them), from older to newer:
```
commit 5f396737d6a3b6af3490d94b51d2fa699a97f193
Author: Ace Eldeib <alexeldeib@gmail.com>
Date:   Thu Oct 17 04:54:03 2019 -0700

    feat: azure vmss min/mix autodiscovery

commit 40475c86f08813b6d245029973bcc822d480973f
Author: David Langworthy <dlan@microsoft.com>
Date:   Thu Oct 17 09:16:54 2019 -0700

    This commit improves the performance of the azure cloud provider.

commit 1ba5455beee06433c0dabc438b5f549f2a5a5b7d
Author: Dong Liu <doliu@microsoft.com>
Date:   Tue Oct 29 17:01:05 2019 +0800

    Fix config assignment issue

commit 0b8631b833145512514edc3e8b76cbcbaebb591e
Author: David Langworthy <dlan@microsoft.com>
Date:   Mon Oct 21 11:36:47 2019 -0700

    Add mock and mutex

commit fa04326ddeb7900fce5a402e148c2328d8c54f03
Author: David Langworthy <dlan@microsoft.com>
Date:   Wed Nov 6 13:55:00 2019 -0800

    Mitigate race

commit 4f86fbceea2271cbf65eee97ebf01b7bace312dc
Author: David Langworthy <dlan@microsoft.com>
Date:   Wed Nov 6 14:35:14 2019 -0800

    Mitigate race

commit cffb5d88cf3ca1aa1715011ff12ffbb0032dc749
Author: David Langworthy <dlan@microsoft.com>
Date:   Thu Nov 7 09:34:58 2019 -0800

    Finally mitigate race

commit 918e0b0ea3808cdeb033c2ea01e8b0261090cc96
Author: t-qini <t-qini@microsoft.com>
Date:   Wed Dec 4 13:57:15 2019 +0800

    Clear the content of ss.DecreaseTargetSize and shorten the regeneration time of asg cache.

commit 0e0291971b44f7305adbffdf70dd0d4f9579f8b6
Author: Marwan Ahmed <marwanad@microsoft.com>
Date:   Wed Dec 18 13:58:21 2019 -0800

    fix: properly parse azure cloud provider config

commit fc2166fac1ba97fe5ca99cef96ee81ff35e09917
Author: t-qini <t-qini@microsoft.com>
Date:   Mon Dec 23 13:25:41 2019 +0800

    Add VM cache.

commit cf510d34b7f8952428052a046ffb6f598ba6be07
Author: Marwan Ahmed <marwanad@microsoft.com>
Date:   Mon Jan 6 17:59:00 2020 -0800

    dont attempt to parse min and max counts through discoverer

commit b5e393e6661d9a534467a4ac4e025ef776daf83a
Author: Marwan Ahmed <marwanad@microsoft.com>
Date:   Fri Dec 20 16:00:44 2019 -0800

    reduce severity of FindForInstance log message

commit d88a8e512075a809c184493b263ba3ff005cf20f
Author: Marwan Ahmed <marwanad@microsoft.com>
Date:   Mon Jan 13 11:58:39 2020 -0800

    Decrease the number of calls to VMSS API
```

