### PR TITLE
Move DisableScaleDownForLoop to the scaleUp loop

### DIFF
--- a/cluster-autoscaler/core/filter_out_schedulable.go
+++ b/cluster-autoscaler/core/filter_out_schedulable.go
@@ -109,7 +109,6 @@ func (p *filterOutSchedulablePodListProcessor) Process(
 
 	if len(unschedulablePodsToHelp) != len(unschedulablePods) {
 		klog.V(2).Info("Schedulable pods present")
-		context.ProcessorCallbacks.DisableScaleDownForLoop()
 	} else {
 		klog.V(4).Info("No schedulable pods")
 	}

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -437,6 +437,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) errors.AutoscalerError
 			a.lastScaleUpTime = currentTime
 			// No scale down in this iteration.
 			scaleDownStatus.Result = status.ScaleDownInCooldown
+			a.processorCallbacks.DisableScaleDownForLoop()
 			return nil
 		}
 	}

--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -263,7 +263,7 @@ var (
 			Help:      "Quantiles of time taken by cloud provider query by method and success in seconds",
 			MaxAge:    time.Hour,
 		},
-		[]string{"cloud", "method", "success"},
+		[]string{"cloud", "method", "success","code"},
 	)
 )
 


### PR DESCRIPTION
When running the autoscaler with `--max-nodes-total` set and that max is reached downscale is disabled when new unschedulable pods are added.
Preventing the removal of nodes.
If pods are created very frequently by let's say a cronjob, the cluster will never be able to downscale.
In order to fix that behavior i moved the downscale lock from the process to the actual place where scale-up happens.