### PR TITLE
Fix AWS memory capacity estimations

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"math/rand"
 	"os"
 	"regexp"
@@ -365,11 +364,10 @@ func (m *AwsManager) buildNodeFromTemplate(asg *asg, template *asgTemplate) (*ap
 	}
 
 	// TODO: get a real value.
-	instanceMemoryBi := int64(math.Ceil(float64(template.InstanceType.MemoryMb)/1.049) * 1024 * 1024)
 	node.Status.Capacity[apiv1.ResourcePods] = *resource.NewQuantity(110, resource.DecimalSI)
 	node.Status.Capacity[apiv1.ResourceCPU] = *resource.NewQuantity(template.InstanceType.VCPU, resource.DecimalSI)
 	node.Status.Capacity[gpu.ResourceNvidiaGPU] = *resource.NewQuantity(template.InstanceType.GPU, resource.DecimalSI)
-	node.Status.Capacity[apiv1.ResourceMemory] = *resource.NewQuantity(instanceMemoryBi, resource.BinarySI)
+	node.Status.Capacity[apiv1.ResourceMemory] = *resource.NewQuantity(template.InstanceType.MemoryMb*1024*1024, resource.DecimalSI)
 	node.Status.Capacity["storageclass/local-data"] = *resource.NewQuantity(numberOfLocalVolumes(template.InstanceType.InstanceType), resource.DecimalSI)
 
 	resourcesFromTags := extractAllocatableResourcesFromAsg(template.Tags)


### PR DESCRIPTION
AWS API `DescribeInstanceTypes` API (as used by the autoscaler) returns
memory capacities as proper BinarySI values. This replaced chunk seemed
to try to convert megabytes to mebibytes (guessed from the classic 1.049
factor). For larger instance types this amount to a significant
unclaimable memory (eg. i3.8xlarge has 244GiB but with the replaced
chunk, the autoscaler only saw 232GiB).