### PR TITLE
local only: gcp perf improvement on large MIG count

### DIFF
--- a/cluster-autoscaler/core/utils/get_full_nodeinfo.go
+++ b/cluster-autoscaler/core/utils/get_full_nodeinfo.go
@@ -1,0 +1,28 @@
+package utils
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/daemonset"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
+	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+)
+
+// GetFullNodeInfoFromBase returns NodeInfo object built base on provided base TemplateNodeInfo
+func GetFullNodeInfoFromBase(nodeGroupId string, baseNodeInfo *schedulerframework.NodeInfo, daemonsets []*appsv1.DaemonSet, predicateChecker simulator.PredicateChecker, ignoredTaints taints.TaintKeySet) (*schedulerframework.NodeInfo, errors.AutoscalerError) {
+	pods, err := daemonset.GetDaemonSetPodsForNode(baseNodeInfo, daemonsets, predicateChecker)
+	if err != nil {
+		return nil, errors.ToAutoscalerError(errors.InternalError, err)
+	}
+	for _, podInfo := range baseNodeInfo.Pods {
+		pods = append(pods, podInfo.Pod)
+	}
+	fullNodeInfo := schedulerframework.NewNodeInfo(pods...)
+	fullNodeInfo.SetNode(baseNodeInfo.Node())
+	sanitizedNodeInfo, typedErr := sanitizeNodeInfo(fullNodeInfo, nodeGroupId, ignoredTaints)
+	if typedErr != nil {
+		return nil, typedErr
+	}
+	return sanitizedNodeInfo, nil
+}


### PR DESCRIPTION
Caches locks from concurrent refreshes causes significant slowdowns in
utils.GetNodeInfoFromTemplate(), as called by the nodeInfos processor
(or previously, by GetNodeInfosForGroups()). Just caching the nodeInfos
isn't enough: a single invalidated/expired cache entry causing a single
MIG refresh is enough for the processor to be locked for 30s to 6m+ at
every RunOnce loop, slowing down main loop by ~250% on large clusters.

This only affects GCP cloud-provider (having coarse grained caches,
invalidated from multiple concurrent goroutines, and a slow API).

Keeping the local nodeInfos cache up-to-date async in background allows
instant processing while at the same time permit more frequent refreshes
(useful to pick labels changes in ASG/MIGs early).

That's hardly upstreamable (nodeinfo processor is a poor fit for
spawning a background task, hence that code aspect). But impact on large
clusters (hundred MIGs) are potentially significant enough that we want
that change anyway.