### PR TITLE
clarify datadog's own podlistprocessor

### DIFF
--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -31,6 +31,8 @@ import (
 
 	"github.com/spf13/pflag"
 
+	"k8s.io/autoscaler/cluster-autoscaler/processors/datadog/pods"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/server/mux"
 	"k8s.io/apiserver/pkg/server/routes"
@@ -307,7 +309,7 @@ func buildAutoscaler() (core.Autoscaler, error) {
 	}
 
 	opts.Processors = ca_processors.DefaultProcessors()
-	opts.Processors.PodListProcessor = core.NewFilterOutSchedulablePodListProcessor()
+	opts.Processors.PodListProcessor = pods.NewFilterOutSchedulablePodListProcessor()
 
 	nodeInfoComparatorBuilder := nodegroupset.CreateGenericNodeInfoComparator
 	if autoscalingOptions.CloudProviderName == cloudprovider.AzureProviderName {

--- a/cluster-autoscaler/processors/datadog/pods/filter_out_schedulable.go
+++ b/cluster-autoscaler/processors/datadog/pods/filter_out_schedulable.go
@@ -1,0 +1,247 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pods
+
+import (
+	"sort"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/core/utils"
+	"k8s.io/autoscaler/cluster-autoscaler/metrics"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+
+	apiv1 "k8s.io/api/core/v1"
+	klog "k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/api/v1/pod"
+)
+
+type filterOutSchedulablePodListProcessor struct {
+	schedulablePodsNodeHints map[types.UID]string
+}
+
+// NewFilterOutSchedulablePodListProcessor creates a PodListProcessor filtering out schedulable pods
+func NewFilterOutSchedulablePodListProcessor() *filterOutSchedulablePodListProcessor {
+	return &filterOutSchedulablePodListProcessor{
+		schedulablePodsNodeHints: make(map[types.UID]string),
+	}
+}
+
+// Process filters out pods which are schedulable from list of unschedulable pods.
+func (p *filterOutSchedulablePodListProcessor) Process(
+	context *context.AutoscalingContext,
+	unschedulablePods []*apiv1.Pod) ([]*apiv1.Pod, error) {
+	// We need to check whether pods marked as unschedulable are actually unschedulable.
+	// It's likely we added a new node and the scheduler just haven't managed to put the
+	// pod on in yet. In this situation we don't want to trigger another scale-up.
+	//
+	// It's also important to prevent uncontrollable cluster growth if CA's simulated
+	// scheduler differs in opinion with real scheduler. Example of such situation:
+	// - CA and Scheduler has slightly different configuration
+	// - Scheduler can't schedule a pod and marks it as unschedulable
+	// - CA added a node which should help the pod
+	// - Scheduler doesn't schedule the pod on the new node
+	//   because according to it logic it doesn't fit there
+	// - CA see the pod is still unschedulable, so it adds another node to help it
+	//
+	// With the check enabled the last point won't happen because CA will ignore a pod
+	// which is supposed to schedule on an existing node.
+
+	klog.V(4).Infof("Filtering out schedulables")
+	filterOutSchedulableStart := time.Now()
+	var unschedulablePodsToHelp []*apiv1.Pod
+
+	pvcLister := context.ListerRegistry.PersistentVolumeClaimLister()
+	for _, po := range unschedulablePods {
+		var volumes []apiv1.Volume
+		for _, vol := range po.Spec.Volumes {
+			if vol.PersistentVolumeClaim == nil {
+				volumes = append(volumes, vol)
+				continue
+			}
+			pvc, err := pvcLister.PersistentVolumeClaims(po.Namespace).Get(vol.PersistentVolumeClaim.ClaimName)
+			if err != nil {
+				volumes = append(volumes, vol)
+				continue
+			}
+			if *pvc.Spec.StorageClassName != "local-data" {
+				volumes = append(volumes, vol)
+				continue
+			}
+
+			if len(po.Spec.Containers[0].Resources.Requests) == 0 {
+				po.Spec.Containers[0].Resources.Requests = apiv1.ResourceList{}
+			}
+			if len(po.Spec.Containers[0].Resources.Limits) == 0 {
+				po.Spec.Containers[0].Resources.Limits = apiv1.ResourceList{}
+			}
+
+			po.Spec.Containers[0].Resources.Requests["storageclass/local-data"] = *resource.NewQuantity(1, resource.DecimalSI)
+			po.Spec.Containers[0].Resources.Limits["storageclass/local-data"] = *resource.NewQuantity(1, resource.DecimalSI)
+		}
+		po.Spec.Volumes = volumes
+	}
+
+	unschedulablePodsToHelp, err := p.filterOutSchedulableByPacking(unschedulablePods, context.ClusterSnapshot,
+		context.PredicateChecker)
+
+	if err != nil {
+		return nil, err
+	}
+
+	metrics.UpdateDurationFromStart(metrics.FilterOutSchedulable, filterOutSchedulableStart)
+
+	if len(unschedulablePodsToHelp) != len(unschedulablePods) {
+		klog.V(2).Info("Schedulable pods present")
+		context.ProcessorCallbacks.DisableScaleDownForLoop()
+	} else {
+		klog.V(4).Info("No schedulable pods")
+	}
+	return unschedulablePodsToHelp, nil
+}
+
+func (p *filterOutSchedulablePodListProcessor) CleanUp() {
+}
+
+// filterOutSchedulableByPacking checks whether pods from <unschedulableCandidates> marked as
+// unschedulable can be scheduled on free capacity on existing nodes by trying to pack the pods. It
+// tries to pack the higher priority pods first. It takes into account pods that are bound to node
+// and will be scheduled after lower priority pod preemption.
+func (p *filterOutSchedulablePodListProcessor) filterOutSchedulableByPacking(
+	unschedulableCandidates []*apiv1.Pod,
+	clusterSnapshot simulator.ClusterSnapshot,
+	predicateChecker simulator.PredicateChecker) ([]*apiv1.Pod, error) {
+	unschedulablePodsCache := make(utils.PodSchedulableMap)
+
+	// Sort unschedulable pods by importance
+	sort.Slice(unschedulableCandidates, func(i, j int) bool {
+		return moreImportantPod(unschedulableCandidates[i], unschedulableCandidates[j])
+	})
+
+	// Pods which remain unschedulable
+	var unschedulablePods []*apiv1.Pod
+
+	// Try to schedule based on hints
+	podsFilteredUsingHints := 0
+	podsToCheckAgainstAllNodes := make([]*apiv1.Pod, 0, len(unschedulableCandidates))
+	for _, pod := range unschedulableCandidates {
+		scheduledOnHintedNode := false
+		if hintedNodeName, hintFound := p.schedulablePodsNodeHints[pod.UID]; hintFound {
+			nodeInfo, _ := clusterSnapshot.NodeInfos().Get(hintedNodeName)
+			if predicateChecker.CheckPredicates(clusterSnapshot, pod, hintedNodeName) == nil && isLivingNode(nodeInfo) {
+				// We treat predicate error and missing node error here in the same way
+				scheduledOnHintedNode = true
+				podsFilteredUsingHints++
+				klog.V(4).Infof("Pod %s.%s marked as unschedulable can be scheduled on node %s (based on hinting). Ignoring"+
+					" in scale up.", pod.Namespace, pod.Name, hintedNodeName)
+
+				if err := clusterSnapshot.AddPod(pod, hintedNodeName); err != nil {
+					return nil, err
+				}
+			}
+		}
+
+		if !scheduledOnHintedNode {
+			podsToCheckAgainstAllNodes = append(podsToCheckAgainstAllNodes, pod)
+			delete(p.schedulablePodsNodeHints, pod.UID)
+		}
+	}
+	klog.V(4).Infof("Filtered out %d pods using hints", podsFilteredUsingHints)
+
+	// Cleanup hints map
+	foundPods := make(map[types.UID]bool)
+	for _, pod := range unschedulableCandidates {
+		foundPods[pod.UID] = true
+	}
+	for hintedPodUID := range p.schedulablePodsNodeHints {
+		if !foundPods[hintedPodUID] {
+			delete(p.schedulablePodsNodeHints, hintedPodUID)
+		}
+	}
+
+	// Try to bin pack remaining pods
+	unschedulePodsCacheHitCounter := 0
+	for _, pod := range podsToCheckAgainstAllNodes {
+		_, found := unschedulablePodsCache.Get(pod)
+		if found {
+			// Cache hit for similar pod; assuming unschedulable without running predicates
+			unschedulablePods = append(unschedulablePods, pod)
+			unschedulePodsCacheHitCounter++
+			continue
+		}
+		nodeName, err := predicateChecker.FitsAnyNodeMatching(clusterSnapshot, pod, func(nodeInfo *schedulerframework.NodeInfo) bool {
+			return isLivingNode(nodeInfo)
+		})
+		if err == nil {
+			klog.V(4).Infof("Pod %s.%s marked as unschedulable can be scheduled on node %s. Ignoring"+
+				" in scale up.", pod.Namespace, pod.Name, nodeName)
+			if err := clusterSnapshot.AddPod(pod, nodeName); err != nil {
+				return nil, err
+			}
+			// Store hint for pod placement
+			p.schedulablePodsNodeHints[pod.UID] = nodeName
+		} else {
+			unschedulablePods = append(unschedulablePods, pod)
+			// cache negative result
+			unschedulablePodsCache.Set(pod, nil)
+		}
+	}
+	klog.V(4).Infof("%v pods were kept as unschedulable based on caching", unschedulePodsCacheHitCounter)
+	klog.V(4).Infof("%v pods marked as unschedulable can be scheduled.", len(unschedulableCandidates)-len(unschedulablePods))
+	return unschedulablePods, nil
+}
+
+// filter out dead nodes (having "unknown" NodeReady condition for over 10mn), so we can ignore them if hinted.
+// Needed for 1.10 clusters, until we set TaintBasedEvictions feature gate to "true" there (already enabled
+// by default on clusters using k8s v1.14 and up): TaintBasedEvictions places a node.kubernetes.io/unreachable
+// taint on dead nodes, that helps the CA to consider them unschedulable (unless explicitely tolerated).
+func isLivingNode(nodeInfo *schedulerframework.NodeInfo) bool {
+	if nodeInfo == nil {
+		// we only care about filtering out nodes having "unknown" status.
+		return true
+	}
+
+	node := nodeInfo.Node()
+	if node == nil && node.Status.Conditions == nil {
+		return true
+	}
+
+	for _, cond := range node.Status.Conditions {
+		if cond.Type != apiv1.NodeReady {
+			continue
+		}
+		if cond.Status != apiv1.ConditionUnknown {
+			continue
+		}
+		if cond.LastTransitionTime.Time.Add(10 * time.Minute).Before(time.Now()) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func moreImportantPod(pod1, pod2 *apiv1.Pod) bool {
+	// based on schedulers MoreImportantPod but does not compare Pod.Status.StartTime which does not make sense
+	// for unschedulable pods
+	p1 := pod.GetPodPriority(pod1)
+	p2 := pod.GetPodPriority(pod2)
+	return p1 > p2
+}

--- a/cluster-autoscaler/processors/datadog/pods/filter_out_schedulable_test.go
+++ b/cluster-autoscaler/processors/datadog/pods/filter_out_schedulable_test.go
@@ -1,0 +1,271 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pods
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterOutSchedulableByPacking(t *testing.T) {
+	// TODO(scheduler_framework_integration) extend/cleanup the test
+	// - add more nodes
+	// - add better naming for pods/scenarios
+
+	p2Owner := metav1.OwnerReference{
+		UID:        "controler_a",
+		Controller: pointer.BoolPtr(true),
+	}
+
+	p1 := BuildTestPod("p1", 1500, 200000)
+
+	// define owner to enable caching
+	p2_1 := BuildTestPod("p2_1", 3000, 200000)
+	p2_1.ObjectMeta.OwnerReferences = append(p2_1.ObjectMeta.OwnerReferences, p2Owner)
+	p2_2 := BuildTestPod("p2_2", 3000, 200000)
+	p2_2.ObjectMeta.OwnerReferences = append(p2_2.ObjectMeta.OwnerReferences, p2Owner)
+
+	p3_1 := BuildTestPod("p3_1", 300, 200000)
+	p3_2 := BuildTestPod("p3_2", 300, 200000)
+
+	scheduledPod1 := BuildTestPod("s1", 100, 200000)
+	scheduledPod1.Spec.NodeName = "node1"
+	scheduledPod2 := BuildTestPod("s2", 1500, 200000)
+	scheduledPod2.Spec.NodeName = "node1"
+
+	podWaitingForPreemption := BuildTestPod("w1", 1500, 200000)
+	var priority100 int32 = 100
+	podWaitingForPreemption.Spec.Priority = &priority100
+	podWaitingForPreemption.Status.NominatedNodeName = "node1"
+
+	p4 := BuildTestPod("p4", 1800, 200000)
+	p4.Spec.Priority = &priority100
+
+	node := BuildTestNode("node1", 2000, 2000000)
+	SetNodeReadyState(node, true, time.Time{})
+
+	tests := []struct {
+		name                    string
+		nodes                   []*apiv1.Node
+		scheduledPods           []*apiv1.Pod
+		pendingPods             []*apiv1.Pod
+		expectedFilteredOutPods []*apiv1.Pod
+	}{
+		{
+			name:                    "scenario 1",
+			nodes:                   []*apiv1.Node{node},
+			scheduledPods:           []*apiv1.Pod{scheduledPod1},
+			pendingPods:             []*apiv1.Pod{p1, p2_1, p2_2, p3_1, p3_2},
+			expectedFilteredOutPods: []*apiv1.Pod{p1, p3_1},
+		},
+		{
+			name:                    "scenario 2",
+			nodes:                   []*apiv1.Node{node},
+			scheduledPods:           []*apiv1.Pod{scheduledPod1, scheduledPod2},
+			pendingPods:             []*apiv1.Pod{p1, p2_1, p2_2, p3_1, p3_2},
+			expectedFilteredOutPods: []*apiv1.Pod{p3_1},
+		},
+		{
+			name:                    "scenario 3",
+			nodes:                   []*apiv1.Node{node},
+			scheduledPods:           []*apiv1.Pod{scheduledPod1},
+			pendingPods:             []*apiv1.Pod{p1, p2_1, p2_2, p3_1, p3_2, p4},
+			expectedFilteredOutPods: []*apiv1.Pod{p4},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			predicateChecker, err := simulator.NewTestPredicateChecker()
+			clusterSnapshot := simulator.NewBasicClusterSnapshot()
+
+			for _, node := range tt.nodes {
+				err := clusterSnapshot.AddNode(node)
+				assert.NoError(t, err)
+			}
+
+			for _, pod := range tt.scheduledPods {
+				err = clusterSnapshot.AddPod(pod, pod.Spec.NodeName)
+				assert.NoError(t, err)
+			}
+
+			filterOutSchedulablePodListProcessor := NewFilterOutSchedulablePodListProcessor()
+
+			err = clusterSnapshot.Fork()
+			assert.NoError(t, err)
+
+			var expectedPodsInSnapshot = tt.scheduledPods
+			for _, pod := range tt.expectedFilteredOutPods {
+				expectedPodsInSnapshot = append(expectedPodsInSnapshot, pod)
+			}
+
+			var expectedPendingPods []*apiv1.Pod
+			for _, pod := range tt.pendingPods {
+				filteredOut := false
+				for _, filteredOutPod := range tt.expectedFilteredOutPods {
+					if pod == filteredOutPod {
+						filteredOut = true
+					}
+				}
+				if !filteredOut {
+					expectedPendingPods = append(expectedPendingPods, pod)
+				}
+			}
+
+			stillPendingPods, err := filterOutSchedulablePodListProcessor.filterOutSchedulableByPacking(tt.pendingPods, clusterSnapshot, predicateChecker)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, stillPendingPods, expectedPendingPods, "pending pods differ")
+
+			// Check if snapshot was correctly modified
+			nodeInfos, err := clusterSnapshot.NodeInfos().List()
+			assert.NoError(t, err)
+			var podsInSnapshot []*apiv1.Pod
+			for _, nodeInfo := range nodeInfos {
+				for _, podInfo := range nodeInfo.Pods {
+					podsInSnapshot = append(podsInSnapshot, podInfo.Pod)
+				}
+			}
+			assert.ElementsMatch(t, podsInSnapshot, expectedPodsInSnapshot, "pods in snapshot differ")
+
+			// Verify hints map; it is very whitebox but better than nothing
+			var podUidsInHintsMap []types.UID
+			for uid := range filterOutSchedulablePodListProcessor.schedulablePodsNodeHints {
+				podUidsInHintsMap = append(podUidsInHintsMap, uid)
+			}
+			var expectedFilteredOutPodUids []types.UID
+			for _, pod := range tt.expectedFilteredOutPods {
+				expectedFilteredOutPodUids = append(expectedFilteredOutPodUids, pod.UID)
+			}
+			assert.ElementsMatch(t, expectedFilteredOutPodUids, podUidsInHintsMap)
+
+			// reset snapshot to initial state and run filterOutSchedulableByPacking with hinting map filled in
+			err = clusterSnapshot.Revert()
+			assert.NoError(t, err)
+			err = clusterSnapshot.Fork()
+			assert.NoError(t, err)
+
+			stillPendingPods, err = filterOutSchedulablePodListProcessor.filterOutSchedulableByPacking(tt.pendingPods, clusterSnapshot, predicateChecker)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, stillPendingPods, expectedPendingPods, "pending pods differ (with hints map)")
+
+		})
+	}
+}
+
+func BenchmarkFilterOutSchedulableByPacking(b *testing.B) {
+	// All pending pods in this scenario are unschedulable - predicates will fail.
+	tests := []struct {
+		name          string
+		nodes         int
+		scheduledPods int
+		pendingPods   int
+	}{
+		{
+			name:          "nothing",
+			nodes:         1,
+			scheduledPods: 30,
+			pendingPods:   1000,
+		},
+		{
+			name:          "small",
+			nodes:         10,
+			scheduledPods: 300,
+			pendingPods:   1000,
+		},
+		{
+			name:          "medium",
+			nodes:         100,
+			scheduledPods: 3000,
+			pendingPods:   1000,
+		},
+		{
+			name:          "large",
+			nodes:         200,
+			scheduledPods: 200,
+			pendingPods:   60000,
+		},
+		{
+			name:          "1k",
+			nodes:         1000,
+			scheduledPods: 1000,
+			pendingPods:   12000,
+		},
+	}
+	snapshots := map[string]func() simulator.ClusterSnapshot{
+		"basic": func() simulator.ClusterSnapshot { return simulator.NewBasicClusterSnapshot() },
+		"delta": func() simulator.ClusterSnapshot { return simulator.NewDeltaClusterSnapshot() },
+	}
+	for snapshotName, snapshotFactory := range snapshots {
+		for _, tc := range tests {
+			b.Run(fmt.Sprintf("%s: %d nodes %d scheduled %d pending", snapshotName, tc.nodes, tc.scheduledPods, tc.pendingPods), func(b *testing.B) {
+				pendingPods := make([]*apiv1.Pod, tc.pendingPods, tc.pendingPods)
+				for i := 0; i < tc.pendingPods; i++ {
+					pendingPods[i] = BuildTestPod(fmt.Sprintf("p-%d", i), 1000, 2000000)
+				}
+				nodes := make([]*apiv1.Node, tc.nodes, tc.nodes)
+				for i := 0; i < tc.nodes; i++ {
+					nodes[i] = BuildTestNode(fmt.Sprintf("n-%d", i), 2000, 200000)
+					SetNodeReadyState(nodes[i], true, time.Time{})
+				}
+				scheduledPods := make([]*apiv1.Pod, tc.scheduledPods, tc.scheduledPods)
+				j := 0
+				for i := 0; i < tc.scheduledPods; i++ {
+					scheduledPods[i] = BuildTestPod(fmt.Sprintf("s-%d", i), 1000, 200000)
+					scheduledPods[i].Spec.NodeName = nodes[j].Name
+					j++
+					if j >= tc.nodes {
+						j = 0
+					}
+				}
+
+				predicateChecker, err := simulator.NewTestPredicateChecker()
+				assert.NoError(b, err)
+
+				clusterSnapshot := snapshotFactory()
+				if err := clusterSnapshot.AddNodes(nodes); err != nil {
+					assert.NoError(b, err)
+				}
+
+				for _, pod := range scheduledPods {
+					if err := clusterSnapshot.AddPod(pod, pod.Spec.NodeName); err != nil {
+						assert.NoError(b, err)
+					}
+				}
+				b.ResetTimer()
+
+				for i := 0; i < b.N; i++ {
+					filterOutSchedulablePodListProcessor := NewFilterOutSchedulablePodListProcessor()
+					if stillPending, err := filterOutSchedulablePodListProcessor.filterOutSchedulableByPacking(pendingPods, clusterSnapshot, predicateChecker); err != nil {
+						assert.NoError(b, err)
+					} else if len(stillPending) < tc.pendingPods {
+						assert.Equal(b, len(stillPending), tc.pendingPods)
+					}
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
This is an unmodified (except for package name) copy of the `core/filter_out_schedulable*` as of current `datadog-master-3.0` branch's HEAD.

Goal is to miminize upstream code changes in this fork: this supersedes e9a967ab8f23cd5bf94d7889c1b495bad483c660 and 721728ce40daa95838521991c35d675e1e810310 patches which we'll drop soon.

Those files (the pod list processor) embed our most non-upstreamable code changes (support for local volumes and old cluster without TBE).

This also gives a foothold for some local-only improvements, without touching upstream code; plans includes:
* Runaway upscale prevention
* Schedulable metrics (pending pods pressure, long pending pods)
* Pods labels selectors (for dedicated autoscaler instances)
* Possibly: un-priorise pods from cronjobs

Not cleaning-up or re-organising the files for now, to keep a clear starting point for local changes history.