### PR TITLE
[local only] Introduce a PodListProcessor frontend

### DIFF
--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -309,7 +309,7 @@ func buildAutoscaler() (core.Autoscaler, error) {
 	}
 
 	opts.Processors = ca_processors.DefaultProcessors()
-	opts.Processors.PodListProcessor = pods.NewFilterOutSchedulablePodListProcessor()
+	opts.Processors.PodListProcessor = pods.NewFilteringPodListProcessor()
 
 	nodeInfoComparatorBuilder := nodegroupset.CreateGenericNodeInfoComparator
 	if autoscalingOptions.CloudProviderName == cloudprovider.AzureProviderName {

--- a/cluster-autoscaler/processors/datadog/pods/filter_long_pending.go
+++ b/cluster-autoscaler/processors/datadog/pods/filter_long_pending.go
@@ -1,0 +1,81 @@
+/*
+  Ensures pods pending for a long time are retried at a slower pace:
+  * We don't want those long pending to slow down scale-up for fresh pods.
+  * If one of those is a pod causing a runaway infinite upscale, we want to give
+    autoscaler some slack time to recover from cooldown, and reap unused nodes.
+*/
+package pods
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+
+	apiv1 "k8s.io/api/core/v1"
+	klog "k8s.io/klog/v2"
+)
+
+const maxDistinctWorkloadsHavingPendingPods = 30
+
+var now = time.Now // unit tests
+
+type pendingTracker struct {
+	firstSeen time.Time
+	lastTried time.Time
+}
+
+type filterOutLongPending struct {
+	seen map[types.UID]*pendingTracker
+}
+
+func NewFilterOutLongPending() *filterOutLongPending {
+	return &filterOutLongPending{
+		seen: make(map[types.UID]*pendingTracker),
+	}
+}
+
+func (p *filterOutLongPending) CleanUp() {}
+
+func (p *filterOutLongPending) Process(ctx *context.AutoscalingContext, pending []*apiv1.Pod) ([]*apiv1.Pod, error) {
+	longPendingBackoff := ctx.AutoscalingOptions.ScaleDownDelayAfterAdd * 2
+
+	currentPods := make(map[types.UID]struct{}, len(pending))
+	allowedPods := make([]*apiv1.Pod, 0)
+
+	if countDistinctOwnerReferences(pending) > maxDistinctWorkloadsHavingPendingPods {
+		klog.Warning("detected pending pods from many distinct workloads:" +
+			" disabling backoff on long pending pods")
+		return pending, nil
+	}
+
+	for _, pod := range pending {
+		currentPods[pod.UID] = struct{}{}
+		if _, found := p.seen[pod.UID]; !found {
+			p.seen[pod.UID] = &pendingTracker{
+				firstSeen: now(),
+				lastTried: now(),
+			}
+		}
+
+		if p.seen[pod.UID].firstSeen.Add(longPendingCutoff).Before(now()) {
+			deadline := p.seen[pod.UID].lastTried.Add(longPendingBackoff)
+			if deadline.After(now()) {
+				klog.Warningf("ignoring long pending pod %s/%s until %s",
+					pod.GetNamespace(), pod.GetName(), deadline)
+				continue
+			}
+		}
+		p.seen[pod.UID].lastTried = now()
+
+		allowedPods = append(allowedPods, pod)
+	}
+
+	for uid := range p.seen {
+		if _, found := currentPods[uid]; !found {
+			delete(p.seen, uid)
+		}
+	}
+
+	return allowedPods, nil
+}

--- a/cluster-autoscaler/processors/datadog/pods/filter_long_pending_test.go
+++ b/cluster-autoscaler/processors/datadog/pods/filter_long_pending_test.go
@@ -1,0 +1,81 @@
+package pods
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+)
+
+var testScaleDownDelay = time.Minute
+
+var testCtx = &context.AutoscalingContext{
+	AutoscalingOptions: config.AutoscalingOptions{
+		ScaleDownDelayAfterAdd: testScaleDownDelay,
+	},
+}
+
+func TestFilterOutLongPending(t *testing.T) {
+	set1 := buildPendingPods(5, "a")
+	set2 := buildPendingPods(2, "b")
+	set1and2 := append(set1, set2...)
+	largeset := buildPendingPods(2*maxDistinctWorkloadsHavingPendingPods, "c")
+
+	tests := []struct {
+		name            string
+		podsInFirstCall []*apiv1.Pod
+		podsInNextCall  []*apiv1.Pod
+		firstCallDelay  time.Duration
+		nextCallDelay   time.Duration
+		expected        []*apiv1.Pod
+	}{
+		{"none filtered when no long pending pods", set1, set1and2, time.Minute, testScaleDownDelay, set1and2},
+		{"long pending pods are filtered out", set1, set1and2, 2 * longPendingCutoff, testScaleDownDelay / 2, set2},
+		{"retry long pending after some time", set1, set1and2, 2 * longPendingCutoff, testScaleDownDelay * 2, set1and2},
+		{"circuit-break and on huge backlog", largeset, largeset, 2 * longPendingCutoff, testScaleDownDelay / 2, largeset},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now = time.Now
+			fp := NewFilterOutLongPending()
+
+			actual, err := fp.Process(testCtx, tt.podsInFirstCall)
+			assert.NoError(t, err)
+
+			now = func() time.Time { return time.Now().Add(tt.firstCallDelay) }
+			actual, err = fp.Process(testCtx, tt.podsInNextCall)
+			assert.ElementsMatch(t, actual, tt.podsInNextCall, "unexpected pods filtered out")
+			assert.NoError(t, err)
+
+			now = func() time.Time { return time.Now().Add(tt.firstCallDelay).Add(tt.nextCallDelay) }
+			actual, err = fp.Process(testCtx, tt.podsInNextCall)
+			assert.ElementsMatch(t, actual, tt.expected, "unexpected pods filtered out")
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func buildPendingPods(count int, setName string) []*apiv1.Pod {
+	var result []*apiv1.Pod
+	trueish := true
+	for i := 0; i < count; i++ {
+		result = append(result, &apiv1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				UID: types.UID(fmt.Sprintf("%s-%d", setName, i)),
+				OwnerReferences: []metav1.OwnerReference{{
+					UID:        types.UID(fmt.Sprintf("%s-%d", setName, i)),
+					Name:       fmt.Sprintf("%s-%d", setName, i),
+					Controller: &trueish,
+				}},
+			},
+		})
+	}
+	return result
+}

--- a/cluster-autoscaler/processors/datadog/pods/filter_schedulable.go
+++ b/cluster-autoscaler/processors/datadog/pods/filter_schedulable.go
@@ -68,7 +68,8 @@ func (p *filterOutSchedulable) Process(
 		return nil, err
 	}
 
-	if len(unschedulablePodsToHelp) != len(unschedulablePods) {
+	if len(filterByAge(unschedulablePodsToHelp, YoungerThan, longPendingCutoff)) !=
+		len(filterByAge(unschedulablePods, YoungerThan, longPendingCutoff)) {
 		klog.V(2).Info("Schedulable pods present")
 		context.ProcessorCallbacks.DisableScaleDownForLoop()
 	} else {

--- a/cluster-autoscaler/processors/datadog/pods/filter_schedulable.go
+++ b/cluster-autoscaler/processors/datadog/pods/filter_schedulable.go
@@ -20,32 +20,30 @@ import (
 	"sort"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/autoscaler/cluster-autoscaler/context"
-	"k8s.io/autoscaler/cluster-autoscaler/core/utils"
-	"k8s.io/autoscaler/cluster-autoscaler/metrics"
-	"k8s.io/autoscaler/cluster-autoscaler/simulator"
-	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
-
 	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	klog "k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/api/v1/pod"
+
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/core/utils"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 )
 
-type filterOutSchedulablePodListProcessor struct {
+type filterOutSchedulable struct {
 	schedulablePodsNodeHints map[types.UID]string
 }
 
-// NewFilterOutSchedulablePodListProcessor creates a PodListProcessor filtering out schedulable pods
-func NewFilterOutSchedulablePodListProcessor() *filterOutSchedulablePodListProcessor {
-	return &filterOutSchedulablePodListProcessor{
+// NewFilterOutSchedulable creates a PodListProcessor filtering out schedulable pods
+func NewFilterOutSchedulable() *filterOutSchedulable {
+	return &filterOutSchedulable{
 		schedulablePodsNodeHints: make(map[types.UID]string),
 	}
 }
 
 // Process filters out pods which are schedulable from list of unschedulable pods.
-func (p *filterOutSchedulablePodListProcessor) Process(
+func (p *filterOutSchedulable) Process(
 	context *context.AutoscalingContext,
 	unschedulablePods []*apiv1.Pod) ([]*apiv1.Pod, error) {
 	// We need to check whether pods marked as unschedulable are actually unschedulable.
@@ -63,50 +61,12 @@ func (p *filterOutSchedulablePodListProcessor) Process(
 	//
 	// With the check enabled the last point won't happen because CA will ignore a pod
 	// which is supposed to schedule on an existing node.
-
-	klog.V(4).Infof("Filtering out schedulables")
-	filterOutSchedulableStart := time.Now()
-	var unschedulablePodsToHelp []*apiv1.Pod
-
-	pvcLister := context.ListerRegistry.PersistentVolumeClaimLister()
-	for _, po := range unschedulablePods {
-		var volumes []apiv1.Volume
-		for _, vol := range po.Spec.Volumes {
-			if vol.PersistentVolumeClaim == nil {
-				volumes = append(volumes, vol)
-				continue
-			}
-			pvc, err := pvcLister.PersistentVolumeClaims(po.Namespace).Get(vol.PersistentVolumeClaim.ClaimName)
-			if err != nil {
-				volumes = append(volumes, vol)
-				continue
-			}
-			if *pvc.Spec.StorageClassName != "local-data" {
-				volumes = append(volumes, vol)
-				continue
-			}
-
-			if len(po.Spec.Containers[0].Resources.Requests) == 0 {
-				po.Spec.Containers[0].Resources.Requests = apiv1.ResourceList{}
-			}
-			if len(po.Spec.Containers[0].Resources.Limits) == 0 {
-				po.Spec.Containers[0].Resources.Limits = apiv1.ResourceList{}
-			}
-
-			po.Spec.Containers[0].Resources.Requests["storageclass/local-data"] = *resource.NewQuantity(1, resource.DecimalSI)
-			po.Spec.Containers[0].Resources.Limits["storageclass/local-data"] = *resource.NewQuantity(1, resource.DecimalSI)
-		}
-		po.Spec.Volumes = volumes
-	}
-
 	unschedulablePodsToHelp, err := p.filterOutSchedulableByPacking(unschedulablePods, context.ClusterSnapshot,
 		context.PredicateChecker)
 
 	if err != nil {
 		return nil, err
 	}
-
-	metrics.UpdateDurationFromStart(metrics.FilterOutSchedulable, filterOutSchedulableStart)
 
 	if len(unschedulablePodsToHelp) != len(unschedulablePods) {
 		klog.V(2).Info("Schedulable pods present")
@@ -117,14 +77,14 @@ func (p *filterOutSchedulablePodListProcessor) Process(
 	return unschedulablePodsToHelp, nil
 }
 
-func (p *filterOutSchedulablePodListProcessor) CleanUp() {
+func (p *filterOutSchedulable) CleanUp() {
 }
 
 // filterOutSchedulableByPacking checks whether pods from <unschedulableCandidates> marked as
 // unschedulable can be scheduled on free capacity on existing nodes by trying to pack the pods. It
 // tries to pack the higher priority pods first. It takes into account pods that are bound to node
 // and will be scheduled after lower priority pod preemption.
-func (p *filterOutSchedulablePodListProcessor) filterOutSchedulableByPacking(
+func (p *filterOutSchedulable) filterOutSchedulableByPacking(
 	unschedulableCandidates []*apiv1.Pod,
 	clusterSnapshot simulator.ClusterSnapshot,
 	predicateChecker simulator.PredicateChecker) ([]*apiv1.Pod, error) {

--- a/cluster-autoscaler/processors/datadog/pods/filter_schedulable_test.go
+++ b/cluster-autoscaler/processors/datadog/pods/filter_schedulable_test.go
@@ -113,7 +113,7 @@ func TestFilterOutSchedulableByPacking(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
-			filterOutSchedulablePodListProcessor := NewFilterOutSchedulablePodListProcessor()
+			filterOutSchedulablePodListProcessor := NewFilterOutSchedulable()
 
 			err = clusterSnapshot.Fork()
 			assert.NoError(t, err)
@@ -258,7 +258,7 @@ func BenchmarkFilterOutSchedulableByPacking(b *testing.B) {
 				b.ResetTimer()
 
 				for i := 0; i < b.N; i++ {
-					filterOutSchedulablePodListProcessor := NewFilterOutSchedulablePodListProcessor()
+					filterOutSchedulablePodListProcessor := NewFilterOutSchedulable()
 					if stillPending, err := filterOutSchedulablePodListProcessor.filterOutSchedulableByPacking(pendingPods, clusterSnapshot, predicateChecker); err != nil {
 						assert.NoError(b, err)
 					} else if len(stillPending) < tc.pendingPods {

--- a/cluster-autoscaler/processors/datadog/pods/processor.go
+++ b/cluster-autoscaler/processors/datadog/pods/processor.go
@@ -22,6 +22,7 @@ func NewFilteringPodListProcessor() *filteringPodListProcessor {
 			NewTransformLocalData(),
 		},
 		filters: []proc.PodListProcessor{
+			NewFilterOutLongPending(),
 			NewFilterOutSchedulable(),
 		},
 	}

--- a/cluster-autoscaler/processors/datadog/pods/processor.go
+++ b/cluster-autoscaler/processors/datadog/pods/processor.go
@@ -1,0 +1,56 @@
+package pods
+
+import (
+	"time"
+
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/metrics"
+	proc "k8s.io/autoscaler/cluster-autoscaler/processors/pods"
+
+	apiv1 "k8s.io/api/core/v1"
+	klog "k8s.io/klog/v2"
+)
+
+type filteringPodListProcessor struct {
+	transforms []proc.PodListProcessor
+	filters    []proc.PodListProcessor
+}
+
+func NewFilteringPodListProcessor() *filteringPodListProcessor {
+	return &filteringPodListProcessor{
+		transforms: []proc.PodListProcessor{
+			NewTransformLocalData(),
+		},
+		filters: []proc.PodListProcessor{
+			NewFilterOutSchedulable(),
+		},
+	}
+}
+
+func (p *filteringPodListProcessor) CleanUp() {}
+
+func (p *filteringPodListProcessor) Process(ctx *context.AutoscalingContext, pending []*apiv1.Pod) ([]*apiv1.Pod, error) {
+	klog.V(4).Infof("Filtering pending pods")
+	start := time.Now()
+
+	var err error
+
+	for _, transform := range p.transforms {
+		pending, err = transform.Process(ctx, pending)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	unschedulablePodsToHelp := make([]*apiv1.Pod, len(pending))
+	copy(unschedulablePodsToHelp, pending)
+	for _, filter := range p.filters {
+		unschedulablePodsToHelp, err = filter.Process(ctx, unschedulablePodsToHelp)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	metrics.UpdateDurationFromStart(metrics.FilterOutSchedulable, start)
+	return unschedulablePodsToHelp, nil
+}

--- a/cluster-autoscaler/processors/datadog/pods/processor_test.go
+++ b/cluster-autoscaler/processors/datadog/pods/processor_test.go
@@ -1,0 +1,76 @@
+package pods
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	proc "k8s.io/autoscaler/cluster-autoscaler/processors/pods"
+
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Test processors frontend by ensuring pipelines are properly wired and chained.
+// Effective filters and transforms are tested individually in other files.
+
+func TestFilteringPodListProcessor(t *testing.T) {
+	fp := filteringPodListProcessor{
+		transforms: []proc.PodListProcessor{
+			&testTransformProcessor{
+				suffix: "-renamed",
+			},
+			&testTransformProcessor{
+				suffix: "-again",
+			},
+		},
+		filters: []proc.PodListProcessor{
+			&testFilterProcessor{
+				filteredName: "p2-renamed-again",
+			},
+		},
+	}
+
+	ctx := &context.AutoscalingContext{}
+
+	in := []*apiv1.Pod{newPod("p1"), newPod("p2")}
+	expected := []*apiv1.Pod{newPod("p1-renamed-again")}
+
+	actual, err := fp.Process(ctx, in)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, actual, expected, "filtered pods differ")
+}
+
+func newPod(name string) *apiv1.Pod {
+	return &apiv1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name}}
+}
+
+type testTransformProcessor struct {
+	suffix string
+}
+
+func (p *testTransformProcessor) Process(ctx *context.AutoscalingContext, pending []*apiv1.Pod) ([]*apiv1.Pod, error) {
+	for _, pod := range pending {
+		pod.SetName(fmt.Sprintf("%s%s", pod.GetName(), p.suffix))
+	}
+	return pending, nil
+}
+
+func (p *testTransformProcessor) CleanUp() {}
+
+type testFilterProcessor struct {
+	filteredName string
+}
+
+func (p *testFilterProcessor) Process(ctx *context.AutoscalingContext, pending []*apiv1.Pod) ([]*apiv1.Pod, error) {
+	var result []*apiv1.Pod
+	for _, pod := range pending {
+		if pod.GetName() != p.filteredName {
+			result = append(result, pod)
+		}
+	}
+	return result, nil
+}
+
+func (p *testFilterProcessor) CleanUp() {}

--- a/cluster-autoscaler/processors/datadog/pods/transform_local_data.go
+++ b/cluster-autoscaler/processors/datadog/pods/transform_local_data.go
@@ -1,0 +1,61 @@
+/*
+  This serves two purposes:
+  * Removes volumes using "local-data" from the internal copy of pods (for the duration
+    of the current autoscaler RunOnce loop). local-data volumes (or any volume using a
+    no-provisioner storage class) are breaking Scheduler Framework's evaluations.
+  * Injects a custom resources request/limit to pods having "local-data".
+    Our autoscaler fork is placing the same resource on NodeInfo templates built
+    from ASG/MIG/VMSS using instance types that offer local-data storage.
+    This restricts candidate/upscalable nodes that satisfy pods using local-data volumes.
+*/
+package pods
+
+import (
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+
+	apiv1 "k8s.io/api/core/v1"
+)
+
+type transformLocalData struct{}
+
+func NewTransformLocalData() *transformLocalData {
+	return &transformLocalData{}
+}
+
+func (p *transformLocalData) CleanUp() {}
+
+func (p *transformLocalData) Process(ctx *context.AutoscalingContext, pods []*apiv1.Pod) ([]*apiv1.Pod, error) {
+	pvcLister := ctx.ListerRegistry.PersistentVolumeClaimLister()
+	for _, po := range pods {
+		var volumes []apiv1.Volume
+		for _, vol := range po.Spec.Volumes {
+			if vol.PersistentVolumeClaim == nil {
+				volumes = append(volumes, vol)
+				continue
+			}
+			pvc, err := pvcLister.PersistentVolumeClaims(po.Namespace).Get(vol.PersistentVolumeClaim.ClaimName)
+			if err != nil {
+				volumes = append(volumes, vol)
+				continue
+			}
+			if *pvc.Spec.StorageClassName != "local-data" {
+				volumes = append(volumes, vol)
+				continue
+			}
+
+			if len(po.Spec.Containers[0].Resources.Requests) == 0 {
+				po.Spec.Containers[0].Resources.Requests = apiv1.ResourceList{}
+			}
+			if len(po.Spec.Containers[0].Resources.Limits) == 0 {
+				po.Spec.Containers[0].Resources.Limits = apiv1.ResourceList{}
+			}
+
+			po.Spec.Containers[0].Resources.Requests["storageclass/local-data"] = *resource.NewQuantity(1, resource.DecimalSI)
+			po.Spec.Containers[0].Resources.Limits["storageclass/local-data"] = *resource.NewQuantity(1, resource.DecimalSI)
+		}
+		po.Spec.Volumes = volumes
+	}
+
+	return pods, nil
+}

--- a/cluster-autoscaler/processors/datadog/pods/transform_local_data_test.go
+++ b/cluster-autoscaler/processors/datadog/pods/transform_local_data_test.go
@@ -1,0 +1,155 @@
+package pods
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
+	v1lister "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	testRemoteClass    = "remote-data"
+	testLocalClass     = "local-data"
+	testNamespace      = "foons"
+	testEmptyResources = corev1.ResourceList{}
+	testLdResources    = corev1.ResourceList{
+		"storageclass/local-data": *resource.NewQuantity(1, resource.DecimalSI),
+	}
+)
+
+func TestTransformLocalDataProcess(t *testing.T) {
+	tests := []struct {
+		name     string
+		pods     []*corev1.Pod
+		pvcs     []*corev1.PersistentVolumeClaim
+		expected []*corev1.Pod
+	}{
+		{
+			"No modification on remote volumes",
+			[]*corev1.Pod{buildPod("pod1", testEmptyResources, testEmptyResources, "pvc-1")},
+			[]*corev1.PersistentVolumeClaim{buildPVC("pvc-1", testRemoteClass)},
+			[]*corev1.Pod{buildPod("pod1", testEmptyResources, testEmptyResources, "pvc-1")},
+		},
+
+		{
+			"Cope with pod not having volumes",
+			[]*corev1.Pod{buildPod("pod1", testEmptyResources, testEmptyResources)},
+			[]*corev1.PersistentVolumeClaim{},
+			[]*corev1.Pod{buildPod("pod1", testEmptyResources, testEmptyResources)},
+		},
+
+		{
+			"local-data volumes are removed, and custom resources added",
+			[]*corev1.Pod{buildPod("pod1", testEmptyResources, testEmptyResources, "pvc-1")},
+			[]*corev1.PersistentVolumeClaim{buildPVC("pvc-1", testLocalClass)},
+			[]*corev1.Pod{buildPod("pod1", testLdResources, testLdResources)},
+		},
+
+		{
+			"mixed local-data and remote volumes don't cause confusion",
+			[]*corev1.Pod{buildPod("pod1", testEmptyResources, testEmptyResources, "pvc-1", "pvc-2", "pvc-3")},
+			[]*corev1.PersistentVolumeClaim{
+				buildPVC("pvc-1", testRemoteClass),
+				buildPVC("pvc-2", testLocalClass),
+				buildPVC("pvc-3", testRemoteClass),
+			},
+			[]*corev1.Pod{buildPod("pod1", testLdResources, testLdResources, "pvc-1", "pvc-3")},
+		},
+
+		{
+			"volumes using missing pvcs are conserved",
+			[]*corev1.Pod{buildPod("pod1", testEmptyResources, testEmptyResources, "pvc-1")},
+			[]*corev1.PersistentVolumeClaim{},
+			[]*corev1.Pod{buildPod("pod1", testEmptyResources, testEmptyResources, "pvc-1")},
+		},
+
+		{
+			"empty pod list don't crash",
+			[]*corev1.Pod{},
+			[]*corev1.PersistentVolumeClaim{},
+			[]*corev1.Pod{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pvcLister, err := newTestPVCLister(tt.pvcs)
+			assert.NoError(t, err)
+
+			registry := kube_util.NewListerRegistry(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, pvcLister)
+			ctx := &context.AutoscalingContext{
+				AutoscalingKubeClients: context.AutoscalingKubeClients{ListerRegistry: registry},
+			}
+
+			actual, err := NewTransformLocalData().Process(ctx, tt.pods)
+			assert.NoError(t, err)
+			assert.True(t, apiequality.Semantic.DeepEqual(tt.expected, actual))
+		})
+	}
+
+}
+
+func newTestPVCLister(pvcs []*corev1.PersistentVolumeClaim) (v1lister.PersistentVolumeClaimLister, error) {
+	store := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	for _, pvc := range pvcs {
+		err := store.Add(pvc)
+		if err != nil {
+			return nil, fmt.Errorf("Error adding object to cache: %v", err)
+		}
+	}
+	return v1lister.NewPersistentVolumeClaimLister(store), nil
+}
+
+func buildPod(name string, requests, limits corev1.ResourceList, claimNames ...string) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+		},
+		Spec: corev1.PodSpec{
+			Volumes: []corev1.Volume{},
+			Containers: []corev1.Container{
+				corev1.Container{
+					Resources: corev1.ResourceRequirements{
+						Requests: requests,
+						Limits:   limits,
+					},
+				},
+			},
+		},
+	}
+
+	for _, name := range claimNames {
+		pod.Spec.Volumes = append(pod.Spec.Volumes,
+			corev1.Volume{
+				Name: name,
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: name,
+					},
+				},
+			})
+	}
+
+	return pod
+}
+
+func buildPVC(name string, storageClassName string) *corev1.PersistentVolumeClaim {
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &storageClassName,
+		},
+	}
+}

--- a/cluster-autoscaler/processors/datadog/pods/utils.go
+++ b/cluster-autoscaler/processors/datadog/pods/utils.go
@@ -1,0 +1,44 @@
+package pods
+
+import (
+	"time"
+
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type AgeCondition int
+
+const (
+	longPendingCutoff = time.Hour * 2
+	YoungerThan       = iota
+	OlderThan         = iota
+)
+
+func countDistinctOwnerReferences(pods []*apiv1.Pod) int {
+	distinctOwners := make(map[types.UID]struct{})
+	for _, pod := range pods {
+		controllerRef := metav1.GetControllerOf(pod)
+		if controllerRef == nil {
+			continue
+		}
+		distinctOwners[controllerRef.UID] = struct{}{}
+	}
+
+	return len(distinctOwners)
+}
+
+func filterByAge(pods []*apiv1.Pod, condition AgeCondition, age time.Duration) []*apiv1.Pod {
+	var filtered []*apiv1.Pod
+	for _, pod := range pods {
+		cutoff := pod.GetCreationTimestamp().Time.Add(age)
+		if condition == YoungerThan && cutoff.After(time.Now()) {
+			filtered = append(filtered, pod)
+		}
+		if condition == OlderThan && cutoff.Before(time.Now()) {
+			filtered = append(filtered, pod)
+		}
+	}
+	return filtered
+}

--- a/cluster-autoscaler/processors/datadog/pods/utils_test.go
+++ b/cluster-autoscaler/processors/datadog/pods/utils_test.go
@@ -1,0 +1,56 @@
+package pods
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestCountDistinctOwnerReferences(t *testing.T) {
+	tests := []struct {
+		name     string
+		pods     []*apiv1.Pod
+		expected int
+	}{
+		{
+			"count all distinct ownerref",
+			[]*apiv1.Pod{testPodWithOwner("a"), testPodWithOwner("b"), testPodWithOwner("c")},
+			3,
+		},
+
+		{
+			"group identical ownerrefs",
+			[]*apiv1.Pod{testPodWithOwner("a"), testPodWithOwner("a"), testPodWithOwner("b")},
+			2,
+		},
+
+		{
+			"don't crash on empty pod list",
+			[]*apiv1.Pod{},
+			0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := countDistinctOwnerReferences(tt.pods)
+			assert.Equal(t, actual, tt.expected)
+		})
+	}
+}
+
+func testPodWithOwner(refname string) *apiv1.Pod {
+	trueish := true
+	return &apiv1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			OwnerReferences: []metav1.OwnerReference{{
+				UID:        types.UID(refname),
+				Name:       refname,
+				Controller: &trueish,
+			}},
+		},
+	}
+}


### PR DESCRIPTION
This is only moving existing code around (not functional changes)
in order to introduce a processor frontend (processor.go) that allows
chaining filters and transformations.

While at it, bring unit tests for our local changes.

New functionalities in follow-up PRs.