### PR TITLE
[local only] Long pending pods filter

### DIFF
--- a/cluster-autoscaler/processors/datadog/pods/filter_long_pending.go
+++ b/cluster-autoscaler/processors/datadog/pods/filter_long_pending.go
@@ -1,0 +1,81 @@
+/*
+  Ensures pods pending for a long time are retried at a slower pace:
+  * We don't want those long pending to slow down scale-up for fresh pods.
+  * If one of those is a pod causing a runaway infinite upscale, we want to give
+    autoscaler some slack time to recover from cooldown, and reap unused nodes.
+*/
+package pods
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+
+	apiv1 "k8s.io/api/core/v1"
+	klog "k8s.io/klog/v2"
+)
+
+const maxDistinctWorkloadsHavingPendingPods = 30
+
+var now = time.Now // unit tests
+
+type pendingTracker struct {
+	firstSeen time.Time
+	lastTried time.Time
+}
+
+type filterOutLongPending struct {
+	seen map[types.UID]*pendingTracker
+}
+
+func NewFilterOutLongPending() *filterOutLongPending {
+	return &filterOutLongPending{
+		seen: make(map[types.UID]*pendingTracker),
+	}
+}
+
+func (p *filterOutLongPending) CleanUp() {}
+
+func (p *filterOutLongPending) Process(ctx *context.AutoscalingContext, pending []*apiv1.Pod) ([]*apiv1.Pod, error) {
+	longPendingBackoff := ctx.AutoscalingOptions.ScaleDownDelayAfterAdd * 2
+
+	currentPods := make(map[types.UID]struct{}, len(pending))
+	allowedPods := make([]*apiv1.Pod, 0)
+
+	if countDistinctOwnerReferences(pending) > maxDistinctWorkloadsHavingPendingPods {
+		klog.Warning("detected pending pods from many distinct workloads:" +
+			" disabling backoff on long pending pods")
+		return pending, nil
+	}
+
+	for _, pod := range pending {
+		currentPods[pod.UID] = struct{}{}
+		if _, found := p.seen[pod.UID]; !found {
+			p.seen[pod.UID] = &pendingTracker{
+				firstSeen: now(),
+				lastTried: now(),
+			}
+		}
+
+		if p.seen[pod.UID].firstSeen.Add(longPendingCutoff).Before(now()) {
+			deadline := p.seen[pod.UID].lastTried.Add(longPendingBackoff)
+			if deadline.After(now()) {
+				klog.Warningf("ignoring long pending pod %s/%s until %s",
+					pod.GetNamespace(), pod.GetName(), deadline)
+				continue
+			}
+		}
+		p.seen[pod.UID].lastTried = now()
+
+		allowedPods = append(allowedPods, pod)
+	}
+
+	for uid := range p.seen {
+		if _, found := currentPods[uid]; !found {
+			delete(p.seen, uid)
+		}
+	}
+
+	return allowedPods, nil
+}

--- a/cluster-autoscaler/processors/datadog/pods/filter_long_pending_test.go
+++ b/cluster-autoscaler/processors/datadog/pods/filter_long_pending_test.go
@@ -1,0 +1,81 @@
+package pods
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+)
+
+var testScaleDownDelay = time.Minute
+
+var testCtx = &context.AutoscalingContext{
+	AutoscalingOptions: config.AutoscalingOptions{
+		ScaleDownDelayAfterAdd: testScaleDownDelay,
+	},
+}
+
+func TestFilterOutLongPending(t *testing.T) {
+	set1 := buildPendingPods(5, "a")
+	set2 := buildPendingPods(2, "b")
+	set1and2 := append(set1, set2...)
+	largeset := buildPendingPods(2*maxDistinctWorkloadsHavingPendingPods, "c")
+
+	tests := []struct {
+		name            string
+		podsInFirstCall []*apiv1.Pod
+		podsInNextCall  []*apiv1.Pod
+		firstCallDelay  time.Duration
+		nextCallDelay   time.Duration
+		expected        []*apiv1.Pod
+	}{
+		{"none filtered when no long pending pods", set1, set1and2, time.Minute, testScaleDownDelay, set1and2},
+		{"long pending pods are filtered out", set1, set1and2, 2 * longPendingCutoff, testScaleDownDelay / 2, set2},
+		{"retry long pending after some time", set1, set1and2, 2 * longPendingCutoff, testScaleDownDelay * 2, set1and2},
+		{"circuit-break and on huge backlog", largeset, largeset, 2 * longPendingCutoff, testScaleDownDelay / 2, largeset},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now = time.Now
+			fp := NewFilterOutLongPending()
+
+			actual, err := fp.Process(testCtx, tt.podsInFirstCall)
+			assert.NoError(t, err)
+
+			now = func() time.Time { return time.Now().Add(tt.firstCallDelay) }
+			actual, err = fp.Process(testCtx, tt.podsInNextCall)
+			assert.ElementsMatch(t, actual, tt.podsInNextCall, "unexpected pods filtered out")
+			assert.NoError(t, err)
+
+			now = func() time.Time { return time.Now().Add(tt.firstCallDelay).Add(tt.nextCallDelay) }
+			actual, err = fp.Process(testCtx, tt.podsInNextCall)
+			assert.ElementsMatch(t, actual, tt.expected, "unexpected pods filtered out")
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func buildPendingPods(count int, setName string) []*apiv1.Pod {
+	var result []*apiv1.Pod
+	trueish := true
+	for i := 0; i < count; i++ {
+		result = append(result, &apiv1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				UID: types.UID(fmt.Sprintf("%s-%d", setName, i)),
+				OwnerReferences: []metav1.OwnerReference{{
+					UID:        types.UID(fmt.Sprintf("%s-%d", setName, i)),
+					Name:       fmt.Sprintf("%s-%d", setName, i),
+					Controller: &trueish,
+				}},
+			},
+		})
+	}
+	return result
+}

--- a/cluster-autoscaler/processors/datadog/pods/filter_schedulable.go
+++ b/cluster-autoscaler/processors/datadog/pods/filter_schedulable.go
@@ -68,7 +68,8 @@ func (p *filterOutSchedulable) Process(
 		return nil, err
 	}
 
-	if len(unschedulablePodsToHelp) != len(unschedulablePods) {
+	if len(filterByAge(unschedulablePodsToHelp, YoungerThan, longPendingCutoff)) !=
+		len(filterByAge(unschedulablePods, YoungerThan, longPendingCutoff)) {
 		klog.V(2).Info("Schedulable pods present")
 		context.ProcessorCallbacks.DisableScaleDownForLoop()
 	} else {

--- a/cluster-autoscaler/processors/datadog/pods/processor.go
+++ b/cluster-autoscaler/processors/datadog/pods/processor.go
@@ -22,6 +22,7 @@ func NewFilteringPodListProcessor() *filteringPodListProcessor {
 			NewTransformLocalData(),
 		},
 		filters: []proc.PodListProcessor{
+			NewFilterOutLongPending(),
 			NewFilterOutSchedulable(),
 		},
 	}

--- a/cluster-autoscaler/processors/datadog/pods/utils.go
+++ b/cluster-autoscaler/processors/datadog/pods/utils.go
@@ -1,0 +1,44 @@
+package pods
+
+import (
+	"time"
+
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type AgeCondition int
+
+const (
+	longPendingCutoff = time.Hour * 2
+	YoungerThan       = iota
+	OlderThan         = iota
+)
+
+func countDistinctOwnerReferences(pods []*apiv1.Pod) int {
+	distinctOwners := make(map[types.UID]struct{})
+	for _, pod := range pods {
+		controllerRef := metav1.GetControllerOf(pod)
+		if controllerRef == nil {
+			continue
+		}
+		distinctOwners[controllerRef.UID] = struct{}{}
+	}
+
+	return len(distinctOwners)
+}
+
+func filterByAge(pods []*apiv1.Pod, condition AgeCondition, age time.Duration) []*apiv1.Pod {
+	var filtered []*apiv1.Pod
+	for _, pod := range pods {
+		cutoff := pod.GetCreationTimestamp().Time.Add(age)
+		if condition == YoungerThan && cutoff.After(time.Now()) {
+			filtered = append(filtered, pod)
+		}
+		if condition == OlderThan && cutoff.Before(time.Now()) {
+			filtered = append(filtered, pod)
+		}
+	}
+	return filtered
+}

--- a/cluster-autoscaler/processors/datadog/pods/utils_test.go
+++ b/cluster-autoscaler/processors/datadog/pods/utils_test.go
@@ -1,0 +1,56 @@
+package pods
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestCountDistinctOwnerReferences(t *testing.T) {
+	tests := []struct {
+		name     string
+		pods     []*apiv1.Pod
+		expected int
+	}{
+		{
+			"count all distinct ownerref",
+			[]*apiv1.Pod{testPodWithOwner("a"), testPodWithOwner("b"), testPodWithOwner("c")},
+			3,
+		},
+
+		{
+			"group identical ownerrefs",
+			[]*apiv1.Pod{testPodWithOwner("a"), testPodWithOwner("a"), testPodWithOwner("b")},
+			2,
+		},
+
+		{
+			"don't crash on empty pod list",
+			[]*apiv1.Pod{},
+			0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := countDistinctOwnerReferences(tt.pods)
+			assert.Equal(t, actual, tt.expected)
+		})
+	}
+}
+
+func testPodWithOwner(refname string) *apiv1.Pod {
+	trueish := true
+	return &apiv1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			OwnerReferences: []metav1.OwnerReference{{
+				UID:        types.UID(refname),
+				Name:       refname,
+				Controller: &trueish,
+			}},
+		},
+	}
+}


### PR DESCRIPTION
Goals of that PodListProcessor are twofold:
* Lower presure on runonce loops by evaluating long pending pods less frequently
* More importantly: free autoscaler cycles to recover from scaledown cooldown, so nodes created for pods causing infinite upscales get gc'ed rather than filling a cluster (and those pods are slowed down)

The delay penalty could be made progressive (eg. 2m then 5m then 10m etc), but for now a static value makes evaluating benefits and impacts easier.

Metrics to come in follow-up PR.