### PR TITLE
[local] Define Datadog custom variables and accessors

### DIFF
--- a/cluster-autoscaler/processors/datadog/common/common.go
+++ b/cluster-autoscaler/processors/datadog/common/common.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+)
+
+var (
+	// DatadogLocalStorageLabel is "true" on nodes offering local storage
+	DatadogLocalStorageLabel = "nodegroups.datadoghq.com/local-storage"
+
+	// DatadogLocalDataResource is a virtual resource placed on new or future
+	// nodes offering local storage, and currently injected as requests on
+	// Pending pods having a PVC for local-data volumes.
+	DatadogLocalDataResource apiv1.ResourceName = "storageclass/local-data"
+
+	// DatadogLocalDataQuantity is the default amount of DatadogLocalDataResource
+	DatadogLocalDataQuantity = resource.NewQuantity(1, resource.DecimalSI)
+)
+
+// NodeHasLocalData returns true if the node holds a local-storage:true label
+func NodeHasLocalData(node *apiv1.Node) bool {
+	if node == nil {
+		return false
+	}
+	value, ok := node.GetLabels()[DatadogLocalStorageLabel]
+	return ok && value == "true"
+}
+
+// SetNodeLocalDataResource updates a NodeInfo with the DatadogLocalDataResource resource
+func SetNodeLocalDataResource(nodeInfo *schedulerframework.NodeInfo) {
+	if nodeInfo == nil || nodeInfo.Node() == nil {
+		return
+	}
+
+	node := nodeInfo.Node()
+	nodeInfo.RemoveNode()
+	if node.Status.Allocatable == nil {
+		node.Status.Allocatable = apiv1.ResourceList{}
+	}
+	if node.Status.Capacity == nil {
+		node.Status.Capacity = apiv1.ResourceList{}
+	}
+	node.Status.Capacity[DatadogLocalDataResource] = DatadogLocalDataQuantity.DeepCopy()
+	node.Status.Allocatable[DatadogLocalDataResource] = DatadogLocalDataQuantity.DeepCopy()
+	nodeInfo.SetNode(node)
+}

--- a/cluster-autoscaler/processors/datadog/common/common.go
+++ b/cluster-autoscaler/processors/datadog/common/common.go
@@ -23,7 +23,7 @@ import (
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 )
 
-var (
+const (
 	// DatadogLocalStorageLabel is "true" on nodes offering local storage
 	DatadogLocalStorageLabel = "nodegroups.datadoghq.com/local-storage"
 
@@ -32,6 +32,7 @@ var (
 	// Pending pods having a PVC for local-data volumes.
 	DatadogLocalDataResource apiv1.ResourceName = "storageclass/local-data"
 
+var (
 	// DatadogLocalDataQuantity is the default amount of DatadogLocalDataResource
 	DatadogLocalDataQuantity = resource.NewQuantity(1, resource.DecimalSI)
 )

--- a/cluster-autoscaler/processors/datadog/common/common_test.go
+++ b/cluster-autoscaler/processors/datadog/common/common_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+)
+
+func TestNodeHasLocalData(t *testing.T) {
+	tests := []struct {
+		name     string
+		node     *corev1.Node
+		expected bool
+	}{
+		{
+			"no labels at all means no local storage",
+			&corev1.Node{},
+			false,
+		},
+		{
+			"no local-data label means no local storage",
+			&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"spam": "egg"},
+				},
+			},
+			false,
+		},
+		{
+			"local-data:false label means no local storage",
+			&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{DatadogLocalStorageLabel: "false"},
+				},
+			},
+			false,
+		},
+		{
+			"local-data:true label means local storage",
+			&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{DatadogLocalStorageLabel: "true"},
+				},
+			},
+			true,
+		},
+		{
+			"nil node doesn't crash, means no local storage",
+			nil,
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, NodeHasLocalData(tt.node), tt.expected)
+		})
+	}
+}
+
+func TestSetNodeLocalDataResource(t *testing.T) {
+	ni := schedulerframework.NewNodeInfo(
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "spam"},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "egg"},
+		},
+	)
+	ni.SetNode(&corev1.Node{})
+
+	SetNodeLocalDataResource(ni)
+
+	nodeValue, ok := ni.Node().Status.Allocatable[DatadogLocalDataResource]
+	assert.True(t, ok)
+	assert.Equal(t, nodeValue, *resource.NewQuantity(1, resource.DecimalSI))
+
+	niValue, ok := ni.Allocatable.ScalarResources[DatadogLocalDataResource]
+	assert.True(t, ok)
+	assert.Equal(t, niValue, int64(1))
+
+	assert.Equal(t, len(ni.Pods), 2)
+}

--- a/cluster-autoscaler/processors/datadog/pods/transform_local_data_test.go
+++ b/cluster-autoscaler/processors/datadog/pods/transform_local_data_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package pods
 
 import (
@@ -7,9 +23,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/datadog/common"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	v1lister "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -21,7 +37,7 @@ var (
 	testNamespace      = "foons"
 	testEmptyResources = corev1.ResourceList{}
 	testLdResources    = corev1.ResourceList{
-		"storageclass/local-data": *resource.NewQuantity(1, resource.DecimalSI),
+		common.DatadogLocalDataResource: common.DatadogLocalDataQuantity.DeepCopy(),
 	}
 )
 


### PR DESCRIPTION
This is meant to isolate, contain and wrap access to our custom
resource (storageclass/local-data) and label (/local-storage)
in a single place, separated in our processors/datadog/ namespace.

Avoid spreading local names and constraints over all the code base.