### PR TITLE
[local] Set local-data custom resource on fresh nodes

### DIFF
--- a/cluster-autoscaler/processors/datadog/pods/filter_schedulable.go
+++ b/cluster-autoscaler/processors/datadog/pods/filter_schedulable.go
@@ -184,6 +184,11 @@ func isLivingNode(nodeInfo *schedulerframework.NodeInfo) bool {
 		return true
 	}
 
+	// fresh but not yet ready nodes should be considered as live nodes
+	if node.CreationTimestamp.Time.Add(5 * time.Minute).After(time.Now()) {
+		return true
+	}
+
 	for _, cond := range node.Status.Conditions {
 		if cond.Type != apiv1.NodeReady {
 			continue

--- a/cluster-autoscaler/processors/datadog/pods/processor.go
+++ b/cluster-autoscaler/processors/datadog/pods/processor.go
@@ -37,6 +37,7 @@ func NewFilteringPodListProcessor() *filteringPodListProcessor {
 	return &filteringPodListProcessor{
 		transforms: []proc.PodListProcessor{
 			NewTransformLocalData(),
+			NewTransformDataNodes(),
 		},
 		filters: []proc.PodListProcessor{
 			NewFilterOutLongPending(),

--- a/cluster-autoscaler/processors/datadog/pods/transform_nodes_local_data.go
+++ b/cluster-autoscaler/processors/datadog/pods/transform_nodes_local_data.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+  This hack completes the other sub-processor that add storageclass/local-data
+  custom resources requests to pods requesting local-data.
+
+  Use case being addressed here is: when a node with local-storage just joined,
+  its PV isn't immediately available, and pods that triggered the upscale will
+  remain pending for a moment. The autoscaler might run during that window,
+  evaluate those pods against the just joined nodes, and would consider them
+  unschedulable as the fresh real nodes don't have the custom local-data
+  resource allocatable (as op. to virtual nodes built from ASG templates).
+  Which would cause a spurious re-upscale.
+
+  Decorating those fresh nodes with the requested resources they were expected
+  to offer when created will help the autoscaler to consider them usable for
+  still pending pods, which then won't be flagged as unschedulable and won't
+  trigger an other upscale.
+
+  Theorically all nodes labeled local-storage:true could be injected that custom
+  resource, for a better accuracy. But side effects of that generalisation
+  needs to be evaluated carefully. For instance, absence of the custom resource
+  prevents the autoscaler to even try to repack stateful pods (as they wouldn't
+  fit anywhere). That's why we limit the change to recent local-data nodes for
+  now (later: evaluate if we can safely apply to all local-data real nodes).
+
+  This replaces a previous workaround that did set those new nodes as "unready"
+  until an LVP pod was running there for 90s, but in a way that don't require
+  altering core, and better mimic normal nodes behaviour.
+*/
+
+package pods
+
+import (
+	"time"
+
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/datadog/common"
+
+	apiv1 "k8s.io/api/core/v1"
+)
+
+const (
+	// NodeReadyGraceDelay is time during which we inject custom resource after a node becomes ready
+	NodeReadyGraceDelay = 5 * time.Minute
+)
+
+type transformDataNodes struct{}
+
+// NewTransformDataNodes returns a processor injecting local data custom resource
+func NewTransformDataNodes() *transformDataNodes {
+	return &transformDataNodes{}
+}
+
+// CleanUp tears down a transformDataNodes processor
+func (p *transformDataNodes) CleanUp() {}
+
+// Process injects local data custom resources to nodes offering local-data storage, that became ready since less than 5mn
+func (p *transformDataNodes) Process(ctx *context.AutoscalingContext, pods []*apiv1.Pod) ([]*apiv1.Pod, error) {
+	nodeInfos, err := ctx.ClusterSnapshot.NodeInfos().List()
+	if err != nil {
+		return pods, err
+	}
+
+	for _, nodeInfo := range nodeInfos {
+		node := nodeInfo.Node()
+		if !common.NodeHasLocalData(node) {
+			continue
+		}
+
+		// TODO: evaluate if that age check is really needed
+		readyTimestamp := time.Now()
+		for _, condition := range node.Status.Conditions {
+			if condition.Type == apiv1.NodeReady && condition.Status == apiv1.ConditionTrue {
+				readyTimestamp = condition.LastTransitionTime.Time
+			}
+		}
+		if readyTimestamp.Add(NodeReadyGraceDelay).Before(time.Now()) {
+			continue
+		}
+
+		common.SetNodeLocalDataResource(nodeInfo)
+	}
+
+	return pods, nil
+}

--- a/cluster-autoscaler/processors/datadog/pods/transform_nodes_local_data_test.go
+++ b/cluster-autoscaler/processors/datadog/pods/transform_nodes_local_data_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pods
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/datadog/common"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+)
+
+func TestTransformDataNodesProcess(t *testing.T) {
+	tests := []struct {
+		name     string
+		node     *corev1.Node
+		expected *corev1.Node
+	}{
+
+		{
+			"Resource is added to fresh nodes having local-data label",
+			buildTestNode("a", NodeReadyGraceDelay/2, true, false),
+			buildTestNode("a", NodeReadyGraceDelay/2, true, true),
+		},
+
+		{
+			"Resource is not added to old nodes having local-data label",
+			buildTestNode("b", 2*NodeReadyGraceDelay, true, false),
+			buildTestNode("b", 2*NodeReadyGraceDelay, true, false),
+		},
+
+		{
+			"Resource is not added to new nodes without local-data label",
+			buildTestNode("c", NodeReadyGraceDelay/2, false, false),
+			buildTestNode("c", NodeReadyGraceDelay/2, false, false),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clusterSnapshot := simulator.NewBasicClusterSnapshot()
+			err := clusterSnapshot.AddNode(tt.node)
+			assert.NoError(t, err)
+
+			ctx := &context.AutoscalingContext{
+				ClusterSnapshot: clusterSnapshot,
+			}
+
+			proc := NewTransformDataNodes()
+			_, err = proc.Process(ctx, []*corev1.Pod{})
+			assert.NoError(t, err)
+
+			actual, err := ctx.ClusterSnapshot.NodeInfos().Get(tt.node.GetName())
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.expected.Status.Capacity, actual.Node().Status.Capacity)
+			assert.Equal(t, tt.expected.Status.Allocatable, actual.Node().Status.Allocatable)
+		})
+	}
+
+}
+
+func buildTestNode(name string, age time.Duration, localDataLabel, localDataResource bool) *corev1.Node {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			SelfLink:          fmt.Sprintf("/api/v1/nodes/%s", name),
+			Labels:            map[string]string{},
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-age)),
+		},
+		Status: corev1.NodeStatus{
+			Capacity:    corev1.ResourceList{},
+			Allocatable: corev1.ResourceList{},
+			Conditions: []corev1.NodeCondition{
+				{
+					Type:               corev1.NodeReady,
+					Status:             corev1.ConditionTrue,
+					LastTransitionTime: metav1.NewTime(time.Now().Add(-age)),
+				},
+			},
+		},
+	}
+
+	if localDataLabel {
+		node.ObjectMeta.Labels[common.DatadogLocalStorageLabel] = "true"
+	}
+
+	if localDataResource {
+		node.Status.Capacity[common.DatadogLocalDataResource] = common.DatadogLocalDataQuantity.DeepCopy()
+		node.Status.Allocatable[common.DatadogLocalDataResource] = common.DatadogLocalDataQuantity.DeepCopy()
+	}
+
+	return node
+}


### PR DESCRIPTION
This is meant to replace a patch that was setting new nodes as NotReady
until their lvp pod was there, with something bound to and contained in
our podsListProcessor, not touching autoscaler core or cloudproviders at
all anymore. Decision is entirely based of the local-data:true label: no
guessing or per cloud provider instances types allowlists needed anymore.

Instead of setting them NotReady, the new nodes that just joined are now
considered as schedulable for pods requesting local-data once they are
ready, which naturaly prevents spurious re-upscales.

For now the change is restricted to new local-data nodes that just became
ready for less than 5mn, as we're assessing wider impact.

The downside is we need to modify the clusterSnapshot content before
filterOutSchedulable runs scheduler predicates with those nodes, which
happens later, also in our own podsListProcessor.