### PR TITLE
[local] backfill pre-stable node labels

### DIFF
--- a/cluster-autoscaler/processors/datadog/nodeinfosprovider/template_only_node_info_provider_test.go
+++ b/cluster-autoscaler/processors/datadog/nodeinfosprovider/template_only_node_info_provider_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
 	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 
@@ -33,7 +34,9 @@ func TestTemplateOnlyNodeInfoProviderProcess(t *testing.T) {
 	assert.NoError(t, err)
 
 	tni := schedulerframework.NewNodeInfo()
-	tni.SetNode(BuildTestNode("tn", 100, 100))
+	tn := BuildTestNode("tn", 100, 100)
+	tn.SetLabels(map[string]string{apiv1.LabelTopologyZone: "planet-earth"})
+	tni.SetNode(tn)
 
 	provider1 := testprovider.NewTestAutoprovisioningCloudProvider(
 		nil, nil, nil, nil, nil,
@@ -57,4 +60,6 @@ func TestTemplateOnlyNodeInfoProviderProcess(t *testing.T) {
 	assert.Equal(t, 2, len(res))
 	assert.Contains(t, res, "ng1")
 	assert.Contains(t, res, "ng2")
+	assert.Contains(t, res["ng1"].Node().GetLabels(), apiv1.LabelZoneFailureDomain)
+	assert.Equal(t, res["ng1"].Node().GetLabels()[apiv1.LabelZoneFailureDomain], "planet-earth")
 }


### PR DESCRIPTION
[Recent upstream changes](https://github.com/kubernetes/autoscaler/commit/8f11490c0c85fcab493af2538b4f51b0c6c72489)
dropped the pre-stable nodes labels (eg. `failure-domain.beta.kubernetes.io/zone`) injection
from cloud providers. Instead, cloud providers are now configured to only
set stable labels (eg. `topology.kubernetes.io/zone`), while `GetNodeInfoFromTemplate`
would mirror (backfill) those stable labels to their pre-stable counterpart
in the generated nodeInfos the autoscaler will use for scheduler evaluations.

This fork doesn't use `GetNodeInfoFromTemplate` at all; before it can be
rebased again, we have to replicate upstream changes in its own nodeinfo
processor to restore pre-stable labels (that might be used by pod's
nodeselectors, affinities, or spread constraints).