### PR TITLE
[local] NodeInfoPodTemplateProcessor implementation

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/README.md
+++ b/cluster-autoscaler/cloudprovider/aws/README.md
@@ -145,6 +145,20 @@ be labeled or tainted when they join the cluster, such as:
 * `k8s.io/cluster-autoscaler/node-template/taint/dedicated`: `NoSchedule`
 * `k8s.io/cluster-autoscaler/node-template/taint/tier:` `batch:NoSchedule`
 
+ASG labels can specify autoscaling options, overriding the global cluster-autoscaler
+settings for the labeled ASGs. Those labels takes the same values format as the
+cluter-autoscaler command line flags they override (a float or a duration, encoded
+as string). Currently supported autoscaling options (and example values) are:
+
+* `k8s.io/cluster-autoscaler/node-template/autoscaling-options/scaledownutilizationthreshold`: `0.5`
+  (overrides `--scale-down-utilization-threshold` value for that specific ASG)
+* `k8s.io/cluster-autoscaler/node-template/autoscaling-options/scaledowngpuutilizationthreshold`: `0.5`
+  (overrides `--scale-down-gpu-utilization-threshold` value for that specific ASG)
+* `k8s.io/cluster-autoscaler/node-template/autoscaling-options/scaledownunneededtime`: `10m0s`
+  (overrides `--scale-down-unneeded-time` value for that specific ASG)
+* `k8s.io/cluster-autoscaler/node-template/autoscaling-options/scaledownunreadytime`: `20m0s`
+  (overrides `--scale-down-unready-time` value for that specific ASG)
+
 **NOTE:** It is your responsibility to ensure such labels and/or taints are
 applied via the node's kubelet configuration at startup. Cluster Autoscaler will not set the node taints for you.
 

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -219,7 +219,10 @@ func (ng *AwsNodeGroup) Delete() error {
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
 func (ng *AwsNodeGroup) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
-	return nil, cloudprovider.ErrNotImplemented
+	if ng.asg == nil || ng.asg.Tags == nil || len(ng.asg.Tags) == 0 {
+		return &defaults, nil
+	}
+	return ng.awsManager.GetAsgOptions(*ng.asg, defaults), nil
 }
 
 // IncreaseSize increases Asg size

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -91,6 +91,7 @@ func newTestAwsManagerWithService(service autoScaling, autoDiscoverySpecs []asgA
 			interrupt:             make(chan struct{}),
 			asgAutoDiscoverySpecs: autoDiscoverySpecs,
 			service:               wrapper,
+			autoscalingOptions:    make(map[AwsRef]map[string]string),
 		},
 	}
 }

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -25,6 +25,7 @@ import (
 	"math/rand"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -39,6 +40,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	klog "k8s.io/klog/v2"
 	provider_aws "k8s.io/legacy-cloud-providers/aws"
@@ -52,6 +54,7 @@ const (
 	refreshInterval         = 1 * time.Minute
 	autoDiscovererTypeASG   = "asg"
 	asgAutoDiscovererKeyTag = "tag"
+	optionsTagsPrefix       = "k8s.io/cluster-autoscaler/node-template/autoscaling-options/"
 )
 
 // AwsManager is handles aws communication and data caching.
@@ -283,6 +286,10 @@ func (m *AwsManager) getAsgs() []*asg {
 	return m.asgCache.Get()
 }
 
+func (m *AwsManager) getAutoscalingOptions(ref AwsRef) map[string]string {
+	return m.asgCache.GetAutoscalingOptions(ref)
+}
+
 // SetAsgSize sets ASG size.
 func (m *AwsManager) SetAsgSize(asg *asg, size int) error {
 	return m.asgCache.SetAsgSize(asg, size)
@@ -346,6 +353,52 @@ func (m *AwsManager) buildInstanceType(asg *asg) (string, error) {
 	}
 
 	return "", errors.New("Unable to get instance type from launch config or launch template")
+}
+
+// GetAsgOptions parse options extracted from ASG tags and merges them with provided defaults
+func (m *AwsManager) GetAsgOptions(asg asg, defaults config.NodeGroupAutoscalingOptions) *config.NodeGroupAutoscalingOptions {
+	options := m.getAutoscalingOptions(asg.AwsRef)
+	if options == nil || len(options) == 0 {
+		return &defaults
+	}
+
+	if stringOpt, found := options[config.DefaultScaleDownUtilizationThresholdKey]; found {
+		if opt, err := strconv.ParseFloat(stringOpt, 64); err != nil {
+			klog.Warning("failed to convert asg %s %s tag to float: %v",
+				asg.Name, config.DefaultScaleDownUtilizationThresholdKey, err)
+		} else {
+			defaults.ScaleDownUtilizationThreshold = opt
+		}
+	}
+
+	if stringOpt, found := options[config.DefaultScaleDownGpuUtilizationThresholdKey]; found {
+		if opt, err := strconv.ParseFloat(stringOpt, 64); err != nil {
+			klog.Warning("failed to convert asg %s %s tag to float: %v",
+				asg.Name, config.DefaultScaleDownGpuUtilizationThresholdKey, err)
+		} else {
+			defaults.ScaleDownGpuUtilizationThreshold = opt
+		}
+	}
+
+	if stringOpt, found := options[config.DefaultScaleDownUnneededTimeKey]; found {
+		if opt, err := time.ParseDuration(stringOpt); err != nil {
+			klog.Warning("failed to convert asg %s %s tag to duration: %v",
+				asg.Name, config.DefaultScaleDownUnneededTimeKey, err)
+		} else {
+			defaults.ScaleDownUnneededTime = opt
+		}
+	}
+
+	if stringOpt, found := options[config.DefaultScaleDownUnreadyTimeKey]; found {
+		if opt, err := time.ParseDuration(stringOpt); err != nil {
+			klog.Warning("failed to convert asg %s %s tag to duration: %v",
+				asg.Name, config.DefaultScaleDownUnreadyTimeKey, err)
+		} else {
+			defaults.ScaleDownUnreadyTime = opt
+		}
+	}
+
+	return &defaults
 }
 
 func (m *AwsManager) buildNodeFromTemplate(asg *asg, template *asgTemplate) (*apiv1.Node, error) {
@@ -417,6 +470,21 @@ func extractLabelsFromAsg(tags []*autoscaling.TagDescription) map[string]string 
 	}
 
 	return result
+}
+
+func extractAutoscalingOptionsFromTags(tags []*autoscaling.TagDescription) map[string]string {
+	options := make(map[string]string)
+	for _, tag := range tags {
+		if !strings.HasPrefix(aws.StringValue(tag.Key), optionsTagsPrefix) {
+			continue
+		}
+		splits := strings.Split(aws.StringValue(tag.Key), optionsTagsPrefix)
+		if len(splits) != 2 || splits[1] == "" {
+			continue
+		}
+		options[splits[1]] = aws.StringValue(tag.Value)
+	}
+	return options
 }
 
 func extractAllocatableResourcesFromAsg(tags []*autoscaling.TagDescription) map[string]*resource.Quantity {

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
@@ -28,6 +28,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
@@ -38,6 +39,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
 	provider_aws "k8s.io/legacy-cloud-providers/aws"
 )
 
@@ -110,6 +112,77 @@ func TestExtractAllocatableResourcesFromAsg(t *testing.T) {
 	assert.Equal(t, (&expectedMemory).String(), labels["memory"].String())
 	expectedEphemeralStorage := resource.MustParse("20G")
 	assert.Equal(t, (&expectedEphemeralStorage).String(), labels["ephemeral-storage"].String())
+}
+
+func TestGetAsgOptions(t *testing.T) {
+	defaultOptions := config.NodeGroupAutoscalingOptions{
+		ScaleDownUtilizationThreshold:    0.1,
+		ScaleDownGpuUtilizationThreshold: 0.2,
+		ScaleDownUnneededTime:            time.Second,
+		ScaleDownUnreadyTime:             time.Minute,
+	}
+
+	tests := []struct {
+		description string
+		tags        map[string]string
+		expected    *config.NodeGroupAutoscalingOptions
+	}{
+		{
+			description: "use defaults on unspecified tags",
+			tags:        make(map[string]string),
+			expected:    &defaultOptions,
+		},
+		{
+			description: "keep defaults on invalid tags values",
+			tags: map[string]string{
+				"scaledownutilizationthreshold": "not-a-float",
+				"scaledownunneededtime":         "not-a-duration",
+				"ScaleDownUnreadyTime":          "",
+			},
+			expected: &defaultOptions,
+		},
+		{
+			description: "use provided tags and fill missing with defaults",
+			tags: map[string]string{
+				"scaledownutilizationthreshold": "0.42",
+				"scaledownunneededtime":         "1h",
+			},
+			expected: &config.NodeGroupAutoscalingOptions{
+				ScaleDownUtilizationThreshold:    0.42,
+				ScaleDownGpuUtilizationThreshold: defaultOptions.ScaleDownGpuUtilizationThreshold,
+				ScaleDownUnneededTime:            time.Hour,
+				ScaleDownUnreadyTime:             defaultOptions.ScaleDownUnreadyTime,
+			},
+		},
+		{
+			description: "ignore unknown tags",
+			tags: map[string]string{
+				"scaledownutilizationthreshold":    "0.6",
+				"scaledowngpuutilizationthreshold": "0.7",
+				"scaledownunneededtime":            "1m",
+				"scaledownunreadytime":             "1h",
+				"notyetspecified":                  "42",
+			},
+			expected: &config.NodeGroupAutoscalingOptions{
+				ScaleDownUtilizationThreshold:    0.6,
+				ScaleDownGpuUtilizationThreshold: 0.7,
+				ScaleDownUnneededTime:            time.Minute,
+				ScaleDownUnreadyTime:             time.Hour,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			testAsg := asg{AwsRef: AwsRef{Name: "testAsg"}}
+			cache, _ := newASGCache(autoScalingWrapper{}, []string{}, []asgAutoDiscoveryConfig{})
+			cache.autoscalingOptions[testAsg.AwsRef] = tt.tags
+			awsManager := &AwsManager{asgCache: cache}
+
+			actual := awsManager.GetAsgOptions(testAsg, defaultOptions)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
 }
 
 func TestBuildNodeFromTemplate(t *testing.T) {

--- a/cluster-autoscaler/cloudprovider/azure/README.md
+++ b/cluster-autoscaler/cloudprovider/azure/README.md
@@ -54,6 +54,26 @@ k8s.io_cluster-autoscaler_node-template_resources_cpu: 3800m
 k8s.io_cluster-autoscaler_node-template_resources_memory: 11Gi
 ```
 
+#### Autoscaling options
+
+Some autoscaling options can be defined per VM Scale Set, with tags.
+Those tags values have the format as the respective cluster-autoscaler flags they override: floats or durations encoded as strings.
+
+Supported options tags (with example values) are:
+```
+# overrides --scale-down-utilization-threshold global value for that specific VM Scale Set
+k8s.io_cluster-autoscaler_node-template_autoscaling-options_scaledownutilizationthreshold: "0.5"
+
+# overrides --scale-down-gpu-utilization-threshold global value for that specific VM Scale Set
+k8s.io_cluster-autoscaler_node-template_autoscaling-options_scaledowngpuutilizationthreshold: "0.5"
+
+# overrides --scale-down-unneeded-time global value for that specific VM Scale Set
+k8s.io_cluster-autoscaler_node-template_autoscaling-options_scaledownunneededtime: "10m0s"
+
+# overrides --scale-down-unready-time global value for that specific VM Scale Set
+k8s.io_cluster-autoscaler_node-template_autoscaling-options_scaledownunreadytime: "20m0s"
+```
+
 ## Deployment manifests
 
 Cluster autoscaler supports four Kubernetes cluster options on Azure:

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -116,7 +116,11 @@ func (scaleSet *ScaleSet) Autoprovisioned() bool {
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
 func (scaleSet *ScaleSet) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
-	return nil, cloudprovider.ErrNotImplemented
+	template, err := scaleSet.getVMSSFromCache()
+	if err != nil {
+		return nil, err.Error()
+	}
+	return scaleSet.manager.GetScaleSetOptions(*template.Name, defaults), nil
 }
 
 // MaxSize returns maximum size of the node group.

--- a/cluster-autoscaler/cloudprovider/azure/azure_template.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_template.go
@@ -28,7 +28,9 @@ import (
 	"k8s.io/klog/v2"
 	"math/rand"
 	"regexp"
+	"strconv"
 	"strings"
+	"time"
 )
 
 func buildInstanceOS(template compute.VirtualMachineScaleSet) string {
@@ -181,6 +183,53 @@ func extractTaintsFromScaleSet(tags map[string]*string) []apiv1.Taint {
 	}
 
 	return taints
+}
+
+func extractAutoscalingOptionsFromScaleSetTags(tags map[string]*string) map[string]string {
+	options := make(map[string]string)
+	for tagName, tagValue := range tags {
+		if !strings.HasPrefix(tagName, nodeOptionsTagName) {
+			continue
+		}
+		resourceName := strings.Split(tagName, nodeOptionsTagName)
+		if len(resourceName) < 2 || resourceName[1] == "" || tagValue == nil {
+			continue
+		}
+		options[resourceName[1]] = strings.ToLower(*tagValue)
+	}
+	return options
+}
+
+func getFloat64Option(options map[string]string, vmssName, name string) (float64, bool) {
+	raw, ok := options[strings.ToLower(name)]
+	if !ok {
+		return 0, false
+	}
+
+	option, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		klog.Warningf("failed to convert VMSS %q tag %s_%s value %q to float: %v",
+			vmssName, nodeOptionsTagName, name, raw, err)
+		return 0, false
+	}
+
+	return option, true
+}
+
+func getDurationOption(options map[string]string, vmssName, name string) (time.Duration, bool) {
+	raw, ok := options[strings.ToLower(name)]
+	if !ok {
+		return 0, false
+	}
+
+	option, err := time.ParseDuration(raw)
+	if err != nil {
+		klog.Warningf("failed to convert VMSS %q tag %s_%s value %q to duration: %v",
+			vmssName, nodeOptionsTagName, name, raw, err)
+		return 0, false
+	}
+
+	return option, true
 }
 
 func extractAllocatableResourcesFromScaleSet(tags map[string]*string) map[string]*resource.Quantity {

--- a/cluster-autoscaler/cloudprovider/azure/azure_util.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_util.go
@@ -81,6 +81,7 @@ const (
 	nodeLabelTagName     = "k8s.io_cluster-autoscaler_node-template_label_"
 	nodeTaintTagName     = "k8s.io_cluster-autoscaler_node-template_taint_"
 	nodeResourcesTagName = "k8s.io_cluster-autoscaler_node-template_resources_"
+	nodeOptionsTagName   = "k8s.io_cluster-autoscaler_node-template_autoscaling-options_"
 )
 
 var (

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
@@ -344,7 +344,7 @@ func newTestGceManager(t *testing.T, testServerURL string, regional bool) *gceMa
 			{"us-central1-f", "n1-standard-1"}: {&gce.MachineType{GuestCpus: 1, MemoryMb: 1}, nil},
 		},
 		migTargetSizeCache:     map[GceRef]int64{},
-		instanceTemplatesCache: map[GceRef]*gce.InstanceTemplate{},
+		instanceTemplatesCache: map[GceRef]*instanceTemplateCacheEntry{},
 		migBaseNameCache:       map[GceRef]string{},
 		concurrentGceRefreshes: 1,
 	}

--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -92,6 +92,8 @@ type AutoscalingOptions struct {
 	CloudProviderName string
 	// NodeGroups is the list of node groups a.k.a autoscaling targets
 	NodeGroups []string
+	// NodeInfoProcessorPodTemplates Enable or disable the NodeInfoProcessor PodTemplate
+	NodeInfoProcessorPodTemplates bool
 	// ScaleDownEnabled is used to allow CA to scale down the cluster
 	ScaleDownEnabled bool
 	// ScaleDownDelayAfterAdd sets the duration from the last scale up to the time when CA starts to check scale down options

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -47,6 +47,9 @@ import (
 	klog "k8s.io/klog/v2"
 )
 
+// GetNodeInfosForGroups is a non intrusive entrypoint for nodeinfos provider override
+var GetNodeInfosForGroups = core_utils.GetNodeInfosForGroups
+
 const (
 	// How old the oldest unschedulable pod should be before starting scale up.
 	unschedulablePodTimeBuffer = 2 * time.Second
@@ -280,7 +283,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) errors.AutoscalerError
 		return typedErr.AddPrefix("Initialize ClusterSnapshot")
 	}
 
-	nodeInfosForGroups, autoscalerError := core_utils.GetNodeInfosForGroups(
+	nodeInfosForGroups, autoscalerError := GetNodeInfosForGroups(
 		readyNodes, a.nodeInfoCache, autoscalingContext.CloudProvider, autoscalingContext.ListerRegistry, daemonsets, autoscalingContext.PredicateChecker, a.ignoredTaints)
 	if autoscalerError != nil {
 		klog.Errorf("Failed to get node infos for groups: %v", autoscalerError)

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -31,6 +31,8 @@ import (
 
 	"github.com/spf13/pflag"
 
+	"k8s.io/autoscaler/cluster-autoscaler/processors/datadog/pods"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/server/mux"
 	"k8s.io/apiserver/pkg/server/routes"
@@ -318,7 +320,7 @@ func buildAutoscaler() (core.Autoscaler, error) {
 	}
 
 	opts.Processors = ca_processors.DefaultProcessors()
-	opts.Processors.PodListProcessor = core.NewFilterOutSchedulablePodListProcessor()
+	opts.Processors.PodListProcessor = pods.NewFilteringPodListProcessor()
 
 	nodeInfoComparatorBuilder := nodegroupset.CreateGenericNodeInfoComparator
 	if autoscalingOptions.CloudProviderName == cloudprovider.AzureProviderName {

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -90,6 +90,7 @@ var (
 	kubeConfigFile         = flag.String("kubeconfig", "", "Path to kubeconfig file with authorization and master location information.")
 	cloudConfig            = flag.String("cloud-config", "", "The path to the cloud provider configuration file.  Empty string for no configuration file.")
 	namespace              = flag.String("namespace", "kube-system", "Namespace in which cluster-autoscaler run.")
+	podTemplatesProcessor  = flag.Bool("node-info-processor-podtemplate", false, "Enable PodTemplate NodeInfoProcessor to consider specific PodTemplate as DaemonSet")
 	scaleDownEnabled       = flag.Bool("scale-down-enabled", true, "Should CA scale down the cluster")
 	scaleDownDelayAfterAdd = flag.Duration("scale-down-delay-after-add", 10*time.Minute,
 		"How long after scale up that scale down evaluation resumes")
@@ -233,6 +234,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		MinMemoryTotal:                     minMemoryTotal,
 		GpuTotal:                           parsedGpuTotal,
 		NodeGroups:                         *nodeGroupsFlag,
+		NodeInfoProcessorPodTemplates:      *podTemplatesProcessor,
 		ScaleDownDelayAfterAdd:             *scaleDownDelayAfterAdd,
 		ScaleDownDelayAfterDelete:          *scaleDownDelayAfterDelete,
 		ScaleDownDelayAfterFailure:         *scaleDownDelayAfterFailure,

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/spf13/pflag"
 
+	"k8s.io/autoscaler/cluster-autoscaler/processors/datadog/nodeinfos/podtemplates"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/datadog/nodeinfosprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/datadog/pods"
 
@@ -343,6 +344,11 @@ func buildAutoscaler() (core.Autoscaler, error) {
 	metrics.UpdateMaxNodesCount(autoscalingOptions.MaxNodesTotal)
 	metrics.UpdateCPULimitsCores(autoscalingOptions.MinCoresTotal, autoscalingOptions.MaxCoresTotal)
 	metrics.UpdateMemoryLimitsBytes(autoscalingOptions.MinMemoryTotal, autoscalingOptions.MaxMemoryTotal)
+
+	// Datadog only: Configure the PodTemplateProcessor to support extra Daemonset workloads
+	if autoscalingOptions.NodeInfoProcessorPodTemplates {
+		opts.Processors.NodeInfoProcessor = podtemplates.NewNodeInfoWithPodTemplateProcessor(&opts)
+	}
 
 	// Datadog only: hook our "ASG template only" nodeInfos provider; not in the cleanest, but in the less
 	// intrusive and most rebase friendly way we can; until a "nodeInfos provider processor" makes it upstream.

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/spf13/pflag"
 
+	"k8s.io/autoscaler/cluster-autoscaler/processors/datadog/nodeinfosprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/datadog/pods"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -340,6 +341,10 @@ func buildAutoscaler() (core.Autoscaler, error) {
 	metrics.UpdateMaxNodesCount(autoscalingOptions.MaxNodesTotal)
 	metrics.UpdateCPULimitsCores(autoscalingOptions.MinCoresTotal, autoscalingOptions.MaxCoresTotal)
 	metrics.UpdateMemoryLimitsBytes(autoscalingOptions.MinMemoryTotal, autoscalingOptions.MaxMemoryTotal)
+
+	// Datadog only: hook our "ASG template only" nodeInfos provider; not in the cleanest, but in the less
+	// intrusive and most rebase friendly way we can; until a "nodeInfos provider processor" makes it upstream.
+	core.GetNodeInfosForGroups = nodeinfosprovider.NewTemplateOnlyNodeInfoProvider().GetNodeInfosForGroups
 
 	// Create autoscaler.
 	return core.NewAutoscaler(opts)

--- a/cluster-autoscaler/processors/datadog/common/common.go
+++ b/cluster-autoscaler/processors/datadog/common/common.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+const (
+	// DatadogLocalStorageLabel is "true" on nodes offering local storage
+	DatadogLocalStorageLabel = "nodegroups.datadoghq.com/local-storage"
+
+	// DatadogLocalDataResource is a virtual resource placed on new or future
+	// nodes offering local storage, and currently injected as requests on
+	// Pending pods having a PVC for local-data volumes.
+	DatadogLocalDataResource apiv1.ResourceName = "storageclass/local-data"
+)
+
+var (
+	// DatadogLocalDataQuantity is the default amount of DatadogLocalDataResource
+	DatadogLocalDataQuantity = resource.NewQuantity(1, resource.DecimalSI)
+)
+
+// NodeHasLocalData returns true if the node holds a local-storage:true label
+func NodeHasLocalData(node *apiv1.Node) bool {
+	if node == nil {
+		return false
+	}
+	value, ok := node.GetLabels()[DatadogLocalStorageLabel]
+	return ok && value == "true"
+}
+
+// SetNodeLocalDataResource updates a NodeInfo with the DatadogLocalDataResource resource
+func SetNodeLocalDataResource(nodeInfo *schedulerframework.NodeInfo) {
+	if nodeInfo == nil || nodeInfo.Node() == nil {
+		return
+	}
+
+	node := nodeInfo.Node()
+	nodeInfo.RemoveNode()
+	if node.Status.Allocatable == nil {
+		node.Status.Allocatable = apiv1.ResourceList{}
+	}
+	if node.Status.Capacity == nil {
+		node.Status.Capacity = apiv1.ResourceList{}
+	}
+	node.Status.Capacity[DatadogLocalDataResource] = DatadogLocalDataQuantity.DeepCopy()
+	node.Status.Allocatable[DatadogLocalDataResource] = DatadogLocalDataQuantity.DeepCopy()
+	nodeInfo.SetNode(node)
+}

--- a/cluster-autoscaler/processors/datadog/common/common_test.go
+++ b/cluster-autoscaler/processors/datadog/common/common_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+func TestNodeHasLocalData(t *testing.T) {
+	tests := []struct {
+		name     string
+		node     *corev1.Node
+		expected bool
+	}{
+		{
+			"no labels at all means no local storage",
+			&corev1.Node{},
+			false,
+		},
+		{
+			"no local-data label means no local storage",
+			&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"spam": "egg"},
+				},
+			},
+			false,
+		},
+		{
+			"local-data:false label means no local storage",
+			&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{DatadogLocalStorageLabel: "false"},
+				},
+			},
+			false,
+		},
+		{
+			"local-data:true label means local storage",
+			&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{DatadogLocalStorageLabel: "true"},
+				},
+			},
+			true,
+		},
+		{
+			"nil node doesn't crash, means no local storage",
+			nil,
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, NodeHasLocalData(tt.node), tt.expected)
+		})
+	}
+}
+
+func TestSetNodeLocalDataResource(t *testing.T) {
+	ni := schedulerframework.NewNodeInfo(
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "spam"},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "egg"},
+		},
+	)
+	ni.SetNode(&corev1.Node{})
+
+	SetNodeLocalDataResource(ni)
+
+	nodeValue, ok := ni.Node().Status.Allocatable[DatadogLocalDataResource]
+	assert.True(t, ok)
+	assert.Equal(t, nodeValue, *resource.NewQuantity(1, resource.DecimalSI))
+
+	niValue, ok := ni.Allocatable.ScalarResources[DatadogLocalDataResource]
+	assert.True(t, ok)
+	assert.Equal(t, niValue, int64(1))
+
+	assert.Equal(t, len(ni.Pods), 2)
+}

--- a/cluster-autoscaler/processors/datadog/nodeinfos/podtemplates/node_info_with_podtemplates_processors.go
+++ b/cluster-autoscaler/processors/datadog/nodeinfos/podtemplates/node_info_with_podtemplates_processors.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podtemplates
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	apiv1 "k8s.io/api/core/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+
+	client "k8s.io/client-go/kubernetes"
+	v1lister "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/core"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/nodeinfos"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+	scheduler_utils "k8s.io/autoscaler/cluster-autoscaler/utils/scheduler"
+	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+const (
+	// PodTemplateDaemonSetLabelKey use as label key on PodTemplate corresponding to an extra Daemonset.
+	PodTemplateDaemonSetLabelKey = "cluster-autoscaler.kubernetes.io/daemonset-pod"
+	// PodTemplateDaemonSetLabelValueTrue use as PodTemplateDaemonSetLabelKey label value.
+	PodTemplateDaemonSetLabelValueTrue = "true"
+)
+
+// NewNodeInfoWithPodTemplateProcessor returns a default instance of NodeInfoProcessor.
+func NewNodeInfoWithPodTemplateProcessor(opts *core.AutoscalerOptions) nodeinfos.NodeInfoProcessor {
+	internalContext, cancelFunc := context.WithCancel(context.Background())
+
+	return &nodeInfoWithPodTemplateProcessor{
+		ctx:               internalContext,
+		cancelFunc:        cancelFunc,
+		podTemplateLister: newPodTemplateLister(opts.KubeClient, internalContext.Done()),
+	}
+}
+
+// nodeInfoWithPodTemplateProcessor add possible PodTemplates in nodeInfos.
+type nodeInfoWithPodTemplateProcessor struct {
+	podTemplateLister v1lister.PodTemplateLister
+
+	ctx        context.Context
+	cancelFunc func()
+}
+
+// Process returns unchanged nodeInfos.
+func (p *nodeInfoWithPodTemplateProcessor) Process(ctx *ca_context.AutoscalingContext, nodeInfosForNodeGroups map[string]*schedulerframework.NodeInfo) (map[string]*schedulerframework.NodeInfo, error) {
+	// here we can use empty snapshot, since the NodeInfos that will be updated
+	// are from CloudProvider NodeTemplates.
+	clusterSnapshot := simulator.NewBasicClusterSnapshot()
+
+	// retrieve only once the podTemplates list.
+	// This list will be used for each NodeGroup.
+	podTemplates, err := p.podTemplateLister.List(labels.Everything())
+	if err != nil {
+		return nil, errors.ToAutoscalerError(errors.InternalError, err)
+	}
+
+	result := make(map[string]*schedulerframework.NodeInfo, len(nodeInfosForNodeGroups))
+	var errs []error
+	for id, nodeInfo := range nodeInfosForNodeGroups {
+		var newNodeInfo *schedulerframework.NodeInfo
+		var err error
+
+		// At Datadog we only receive nodeInfos from Cloud provider templates
+		// It means that all nodeInfo needs to decorated with podTemplates
+		newNodeInfo, err = getNodeInfoWithPodTemplates(nodeInfo, podTemplates, clusterSnapshot, ctx.PredicateChecker)
+		if err != nil {
+			errs = append(errs, err)
+		}
+
+		result[id] = newNodeInfo
+	}
+
+	return result, utilerrors.NewAggregate(errs)
+}
+
+// CleanUp cleans up processor's internal structuxres.
+func (p *nodeInfoWithPodTemplateProcessor) CleanUp() {
+	p.cancelFunc()
+}
+
+func newPodTemplateLister(kubeClient client.Interface, stopchannel <-chan struct{}) v1lister.PodTemplateLister {
+	podTemplateWatchOption := func(options *metav1.ListOptions) {
+		options.FieldSelector = fields.Everything().String()
+		options.LabelSelector = labels.SelectorFromSet(getDaemonsetPodTemplateLabelSet()).String()
+	}
+	listWatcher := cache.NewFilteredListWatchFromClient(kubeClient.CoreV1().RESTClient(), "podtemplates", apiv1.NamespaceAll, podTemplateWatchOption)
+	store, reflector := cache.NewNamespaceKeyedIndexerAndReflector(listWatcher, &apiv1.PodTemplate{}, time.Hour)
+	lister := v1lister.NewPodTemplateLister(store)
+	go reflector.Run(stopchannel)
+	return lister
+}
+
+const nodeInfoDeepCopySuffix = "podtemplate"
+
+func getNodeInfoWithPodTemplates(baseNodeInfo *schedulerframework.NodeInfo, podTemplates []*apiv1.PodTemplate, clusterSnapshot *simulator.BasicClusterSnapshot, predicateChecker simulator.PredicateChecker) (*schedulerframework.NodeInfo, error) {
+	// clone baseNodeInfo to not modify the input object.
+	newNodeInfo := scheduler_utils.DeepCopyTemplateNode(baseNodeInfo, nodeInfoDeepCopySuffix)
+	node := newNodeInfo.Node()
+	var pods []*apiv1.Pod
+
+	for _, podInfo := range baseNodeInfo.Pods {
+		pods = append(pods, podInfo.Pod)
+	}
+
+	if err := clusterSnapshot.AddNodeWithPods(node, pods); err != nil {
+		return nil, err
+	}
+
+	for _, podTpl := range podTemplates {
+		newPod := newPod(podTpl, node.Name)
+		err := predicateChecker.CheckPredicates(clusterSnapshot, newPod, node.Name)
+		if err == nil {
+			newNodeInfo.AddPod(newPod)
+		} else if err.ErrorType() == simulator.NotSchedulablePredicateError {
+			// ok; we are just skipping this daemonset
+		} else {
+			// unexpected error
+			return nil, fmt.Errorf("unexpected error while calling PredicateChecker; %v", err)
+		}
+	}
+
+	return newNodeInfo, nil
+}
+
+func getDaemonsetPodTemplateLabelSet() labels.Set {
+	daemonsetPodTemplateLabels := map[string]string{
+		PodTemplateDaemonSetLabelKey: PodTemplateDaemonSetLabelValueTrue,
+	}
+	return labels.Set(daemonsetPodTemplateLabels)
+}
+
+func newPod(pt *apiv1.PodTemplate, nodeName string) *apiv1.Pod {
+	newPod := &apiv1.Pod{Spec: pt.Template.Spec, ObjectMeta: pt.Template.ObjectMeta}
+	newPod.Namespace = pt.Namespace
+	newPod.Name = fmt.Sprintf("%s-pod", pt.Name)
+	newPod.Spec.NodeName = nodeName
+	return newPod
+}

--- a/cluster-autoscaler/processors/datadog/nodeinfos/podtemplates/node_info_with_podtemplates_processors_test.go
+++ b/cluster-autoscaler/processors/datadog/nodeinfos/podtemplates/node_info_with_podtemplates_processors_test.go
@@ -1,0 +1,307 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podtemplates
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	apiv1 "k8s.io/api/core/v1"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	v1lister "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
+
+	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	scheduler_utils "k8s.io/autoscaler/cluster-autoscaler/utils/scheduler"
+)
+
+func Test_getNodeInfoWithPodTemplates(t *testing.T) {
+	nodeName1 := "template-node-template-for-node-1"
+	nodePod1 := newTestPod("bar", "foo", &apiv1.PodSpec{}, nodeName1)
+	nodeInfo := newNodeInfo(nodeName1, 42, nodePod1)
+	nodeInfoUnschedulable := newNodeInfo(nodeName1, 0, nodePod1)
+
+	type args struct {
+		baseNodeInfo *schedulerframework.NodeInfo
+		podTemplates []*apiv1.PodTemplate
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantFunc func() *schedulerframework.NodeInfo
+		wantErr  bool
+	}{
+		{
+			name: "nodeInfo should not be updated",
+			args: args{
+				baseNodeInfo: nodeInfo.Clone(),
+				podTemplates: nil,
+			},
+			wantFunc: func() *schedulerframework.NodeInfo {
+				return scheduler_utils.DeepCopyTemplateNode(nodeInfo, nodeInfoDeepCopySuffix)
+			},
+		},
+		{
+			name: "nodeInfo contains one additional Pod",
+			args: args{
+				baseNodeInfo: nodeInfo.Clone(),
+				podTemplates: []*apiv1.PodTemplate{
+					newPodTemplate("extra-ns", "extra-name", nil),
+				},
+			},
+			wantFunc: func() *schedulerframework.NodeInfo {
+				nodeInfo := scheduler_utils.DeepCopyTemplateNode(nodeInfo, nodeInfoDeepCopySuffix)
+				nodeInfo.AddPod(newTestPod("extra-ns", "extra-name-pod", nil, nodeName1+"-podtemplate"))
+				return nodeInfo
+			},
+		},
+		{
+			name: "nodeInfo unschedulable",
+			args: args{
+				baseNodeInfo: nodeInfoUnschedulable.Clone(),
+				podTemplates: []*apiv1.PodTemplate{
+					newPodTemplate("extra-ns", "extra-name", nil),
+				},
+			},
+			wantFunc: func() *schedulerframework.NodeInfo {
+				return scheduler_utils.DeepCopyTemplateNode(nodeInfoUnschedulable, nodeInfoDeepCopySuffix)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clusterSnapshot := simulator.NewBasicClusterSnapshot()
+			predicateChecker, _ := simulator.NewTestPredicateChecker()
+
+			got, err := getNodeInfoWithPodTemplates(tt.args.baseNodeInfo, tt.args.podTemplates, clusterSnapshot, predicateChecker)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getNodeInfoWithPodTemplates() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			want := tt.wantFunc()
+
+			got.Generation = want.Generation
+
+			resetNodeInfoGeneratedFields(got)
+			resetNodeInfoGeneratedFields(want)
+			assert.EqualValues(t, want, got, "getNodeInfoWithPodTemplates wrong expected value")
+		})
+	}
+}
+
+func Test_nodeInfoWithPodTemplateProcessor_Process(t *testing.T) {
+	namespace := "bar"
+	podName := "foo-dfsdfds"
+	nodeName1 := "template-node-for-template-node-1"
+	wantNodeName1 := fmt.Sprintf("%s-%s", nodeName1, nodeInfoDeepCopySuffix)
+
+	tests := []struct {
+		name                   string
+		podTemplates           []*apiv1.PodTemplate
+		podListerCreation      func(pts []*apiv1.PodTemplate) (v1lister.PodTemplateLister, error)
+		nodeInfosForNodeGroups map[string]*schedulerframework.NodeInfo
+		want                   map[string]*schedulerframework.NodeInfo
+		wantErr                bool
+	}{
+		{
+			name:              "1 pod added",
+			podTemplates:      []*apiv1.PodTemplate{newPodTemplate(namespace, podName, nil)},
+			podListerCreation: newTestDaemonSetLister,
+			nodeInfosForNodeGroups: map[string]*schedulerframework.NodeInfo{
+				nodeName1: newNodeInfo(nodeName1, 42),
+			},
+			want: map[string]*schedulerframework.NodeInfo{
+				nodeName1: newNodeInfo(wantNodeName1, 42, newTestPod(namespace, fmt.Sprintf("%s-pod", podName), nil, wantNodeName1)),
+			},
+			wantErr: false,
+		},
+		{
+			name:              "0 pod added: unschedulable node",
+			podTemplates:      []*apiv1.PodTemplate{newPodTemplate(namespace, podName, nil)},
+			podListerCreation: newTestDaemonSetLister,
+			nodeInfosForNodeGroups: map[string]*schedulerframework.NodeInfo{
+				nodeName1: newNodeInfo(nodeName1, 0),
+			},
+			want: map[string]*schedulerframework.NodeInfo{
+				nodeName1: newNodeInfo(wantNodeName1, 0),
+			},
+			wantErr: false,
+		},
+		{
+			name:         "pod lister error",
+			podTemplates: []*apiv1.PodTemplate{newPodTemplate(namespace, podName, nil)},
+			podListerCreation: func(pts []*apiv1.PodTemplate) (v1lister.PodTemplateLister, error) {
+				podLister := &podTemplateListerMock{}
+				podLister.On("List").Return(pts, fmt.Errorf("unable to list"))
+				return podLister, nil
+			},
+			nodeInfosForNodeGroups: map[string]*schedulerframework.NodeInfo{
+				nodeName1: newNodeInfo(nodeName1, 0),
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			podLister, err := tt.podListerCreation(tt.podTemplates)
+			assert.NoError(t, err, "err should be nil")
+
+			ctx, cancelFunc := context.WithCancel(context.Background())
+
+			p := &nodeInfoWithPodTemplateProcessor{
+				podTemplateLister: podLister,
+				ctx:               ctx,
+				cancelFunc:        cancelFunc,
+			}
+
+			caCtx, err := newTestClusterAutoscalerContext()
+			assert.NoError(t, err, "err should be nil")
+
+			got, err := p.Process(caCtx, tt.nodeInfosForNodeGroups)
+
+			resetNodeInfosGeneratedFields(got)
+			resetNodeInfosGeneratedFields(tt.want)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("nodeInfoWithPodTemplateProcessor.Process() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			assert.EqualValues(t, tt.want, got, "nodeInfoWithPodTemplateProcessor.Process() wrong expected value")
+		})
+	}
+}
+
+func newTestDaemonSetLister(pts []*apiv1.PodTemplate) (v1lister.PodTemplateLister, error) {
+	store := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	for _, pt := range pts {
+		err := store.Add(pt)
+		if err != nil {
+			return nil, fmt.Errorf("Error adding object to cache: %v", err)
+		}
+	}
+	return v1lister.NewPodTemplateLister(store), nil
+}
+
+func newTestClusterAutoscalerContext() (*ca_context.AutoscalingContext, error) {
+	predicateChecker, err := simulator.NewTestPredicateChecker()
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := &ca_context.AutoscalingContext{
+		PredicateChecker: predicateChecker,
+	}
+	return ctx, nil
+}
+
+func newNode(name string, maxPods int64) *apiv1.Node {
+	// define a resource list to allow pod scheduling on this node.
+	newResourceList := apiv1.ResourceList{
+		apiv1.ResourcePods: *resource.NewQuantity(maxPods, resource.DecimalSI),
+	}
+	return &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"kubernetes.io/hostname": name,
+			},
+		},
+		Status: apiv1.NodeStatus{
+			Allocatable: newResourceList,
+		},
+	}
+}
+
+func newNodeInfo(nodeName string, maxPod int64, pods ...*apiv1.Pod) *schedulerframework.NodeInfo {
+	node1 := newNode(nodeName, maxPod)
+	nodeInfo := schedulerframework.NewNodeInfo(pods...)
+	nodeInfo.SetNode(node1)
+
+	return nodeInfo
+}
+
+func newPodTemplate(namespace, name string, spec *apiv1.PodTemplateSpec) *apiv1.PodTemplate {
+	pt := &apiv1.PodTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	if spec != nil {
+		pt.Template = *spec
+	}
+
+	return pt
+}
+
+func newTestPod(namespace, name string, spec *apiv1.PodSpec, nodeName string) *apiv1.Pod {
+	newPod := &apiv1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	newPod.Namespace = namespace
+	newPod.Name = name
+	if spec != nil {
+		newPod.Spec = *spec
+	}
+	newPod.Spec.NodeName = nodeName
+	return newPod
+}
+
+func resetNodeInfosGeneratedFields(nodeInfos map[string]*schedulerframework.NodeInfo) {
+	for _, nodeInfo := range nodeInfos {
+		resetNodeInfoGeneratedFields(nodeInfo)
+	}
+}
+
+func resetNodeInfoGeneratedFields(nodeInfo *schedulerframework.NodeInfo) {
+	nodeInfo.Generation = 0
+	nodeInfo.Node().UID = ""
+	for _, podInfo := range nodeInfo.Pods {
+		podInfo.Pod.UID = ""
+	}
+}
+
+type podTemplateListerMock struct {
+	mock.Mock
+}
+
+// List lists all PodTemplates in the indexer.
+func (p *podTemplateListerMock) List(selector labels.Selector) (ret []*apiv1.PodTemplate, err error) {
+	args := p.Called()
+	return args.Get(0).([]*apiv1.PodTemplate), args.Error(1)
+}
+
+// PodTemplates returns an object that can list and get PodTemplates.
+func (p *podTemplateListerMock) PodTemplates(namespace string) v1lister.PodTemplateNamespaceLister {
+	args := p.Called(namespace)
+	return args.Get(0).(v1lister.PodTemplateNamespaceLister)
+}

--- a/cluster-autoscaler/processors/datadog/nodeinfosprovider/template_only_node_info_provider.go
+++ b/cluster-autoscaler/processors/datadog/nodeinfosprovider/template_only_node_info_provider.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeinfosprovider
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/core/utils"
+	"k8s.io/autoscaler/cluster-autoscaler/metrics"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/datadog/common"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/daemonset"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/labels"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
+	klog "k8s.io/klog/v2"
+	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+const (
+	nodeInfoRefreshInterval                       = 5 * time.Minute
+	templateOnlyFuncLabel   metrics.FunctionLabel = "TemplateOnlyNodeInfoProvider"
+)
+
+type nodeInfoCacheEntry struct {
+	nodeInfo    *schedulerframework.NodeInfo
+	lastRefresh time.Time
+}
+
+// TemplateOnlyNodeInfoProvider return NodeInfos built from node group templates.
+type TemplateOnlyNodeInfoProvider struct {
+	sync.Mutex
+	nodeInfoCache map[string]*nodeInfoCacheEntry
+	cloudProvider cloudprovider.CloudProvider
+	interrupt     chan struct{}
+}
+
+// GetNodeInfosForGroups returns nodeInfos built from node groups (ASGs, MIGs, VMSS) templates only, not real-world nodes.
+// Function signature is meant to match that of std core/utils.go:GetNodeInfosForGroups
+// (even though we don't use some of the args) to ease replacement and subsequent rebases, and keep untouched core tests working.
+// A proper API is being discussed upstream: https://github.com/kubernetes/autoscaler/pull/4191
+func (p *TemplateOnlyNodeInfoProvider) GetNodeInfosForGroups(nodes []*apiv1.Node, nodeInfoCache map[string]*schedulerframework.NodeInfo, cloudProvider cloudprovider.CloudProvider, listers kube_util.ListerRegistry, daemonsets []*appsv1.DaemonSet, predicateChecker simulator.PredicateChecker, ignoredTaints taints.TaintKeySet) (map[string]*schedulerframework.NodeInfo, errors.AutoscalerError) {
+	defer metrics.UpdateDurationFromStart(templateOnlyFuncLabel, time.Now())
+	p.init(cloudProvider)
+
+	p.Lock()
+	defer p.Unlock()
+
+	result := make(map[string]*schedulerframework.NodeInfo)
+	for _, nodeGroup := range p.cloudProvider.NodeGroups() {
+		var err error
+		var nodeInfo *schedulerframework.NodeInfo
+
+		id := nodeGroup.Id()
+		if cacheEntry, found := p.nodeInfoCache[id]; found {
+			nodeInfo, err = GetFullNodeInfoFromBase(id, cacheEntry.nodeInfo, daemonsets, predicateChecker, ignoredTaints)
+		} else {
+			// new nodegroup: this can be slow (locked) but allows discovering new nodegroups faster
+			klog.V(4).Infof("No cached base NodeInfo for %s yet", id)
+			nodeInfo, err = utils.GetNodeInfoFromTemplate(nodeGroup, daemonsets, predicateChecker, ignoredTaints)
+			if common.NodeHasLocalData(nodeInfo.Node()) {
+				common.SetNodeLocalDataResource(nodeInfo)
+			}
+		}
+		if err != nil {
+			klog.Warningf("Failed to build NodeInfo template for %s: %v", id, err)
+			continue
+		}
+
+		labels.UpdateDeprecatedLabels(nodeInfo.Node().ObjectMeta.Labels)
+		result[id] = nodeInfo
+	}
+
+	return result, nil
+}
+
+// init starts a background refresh loop (and a shutdown channel). this should go away
+// once upstream gets a stateful processor API that supports GetNodeInfosForGroups.
+func (p *TemplateOnlyNodeInfoProvider) init(cloudProvider cloudprovider.CloudProvider) {
+	if p.interrupt != nil {
+		return
+	}
+
+	p.interrupt = make(chan struct{})
+	p.cloudProvider = cloudProvider
+	p.refresh()
+	go wait.Until(func() {
+		p.refresh()
+	}, 10*time.Second, p.interrupt)
+}
+
+func (p *TemplateOnlyNodeInfoProvider) refresh() {
+	result := make(map[string]*nodeInfoCacheEntry)
+
+	for _, nodeGroup := range p.cloudProvider.NodeGroups() {
+		id := nodeGroup.Id()
+
+		splay := rand.New(rand.NewSource(time.Now().UnixNano())).Intn(int(nodeInfoRefreshInterval.Seconds() + 1))
+		lastRefresh := time.Now().Add(-time.Second * time.Duration(splay))
+
+		if ng, ok := p.nodeInfoCache[id]; ok {
+			if ng.lastRefresh.Add(nodeInfoRefreshInterval).After(time.Now()) {
+				result[id] = ng
+				continue
+			}
+			lastRefresh = time.Now()
+		}
+
+		nodeInfo, err := nodeGroup.TemplateNodeInfo()
+		if err != nil {
+			klog.Warningf("Unable to build template node for %s: %v", id, err)
+			continue
+		}
+
+		// Virtual nodes in NodeInfo templates (built from ASG / MIGS / VMSS) having the
+		// local-storage:true label now also gets the Datadog local-storage custom resource
+		if common.NodeHasLocalData(nodeInfo.Node()) {
+			common.SetNodeLocalDataResource(nodeInfo)
+		}
+
+		result[id] = &nodeInfoCacheEntry{
+			nodeInfo:    nodeInfo,
+			lastRefresh: lastRefresh,
+		}
+	}
+
+	p.Lock()
+	p.nodeInfoCache = result
+	p.Unlock()
+}
+
+// GetFullNodeInfoFromBase returns a new NodeInfo object built from provided base TemplateNodeInfo
+func GetFullNodeInfoFromBase(nodeGroupId string, baseNodeInfo *schedulerframework.NodeInfo, daemonsets []*appsv1.DaemonSet, predicateChecker simulator.PredicateChecker, ignoredTaints taints.TaintKeySet) (*schedulerframework.NodeInfo, errors.AutoscalerError) {
+	pods, err := daemonset.GetDaemonSetPodsForNode(baseNodeInfo, daemonsets, predicateChecker)
+	if err != nil {
+		return nil, errors.ToAutoscalerError(errors.InternalError, err)
+	}
+	for _, podInfo := range baseNodeInfo.Pods {
+		pods = append(pods, podInfo.Pod)
+	}
+	fullNodeInfo := schedulerframework.NewNodeInfo(pods...)
+	fullNodeInfo.SetNode(baseNodeInfo.Node())
+	sanitizedNodeInfo, typedErr := sanitizeNodeInfo(fullNodeInfo, nodeGroupId, ignoredTaints)
+	if typedErr != nil {
+		return nil, typedErr
+	}
+	return sanitizedNodeInfo, nil
+}
+
+// copied from core/utils/
+func sanitizeNodeInfo(nodeInfo *schedulerframework.NodeInfo, nodeGroupName string, ignoredTaints taints.TaintKeySet) (*schedulerframework.NodeInfo, errors.AutoscalerError) {
+	// Sanitize node name.
+	sanitizedNode, err := sanitizeTemplateNode(nodeInfo.Node(), nodeGroupName, ignoredTaints)
+	if err != nil {
+		return nil, err
+	}
+
+	// Update nodename in pods.
+	sanitizedPods := make([]*apiv1.Pod, 0)
+	for _, podInfo := range nodeInfo.Pods {
+		sanitizedPod := podInfo.Pod.DeepCopy()
+		sanitizedPod.Spec.NodeName = sanitizedNode.Name
+		sanitizedPods = append(sanitizedPods, sanitizedPod)
+	}
+
+	// Build a new node info.
+	sanitizedNodeInfo := schedulerframework.NewNodeInfo(sanitizedPods...)
+	sanitizedNodeInfo.SetNode(sanitizedNode)
+	return sanitizedNodeInfo, nil
+}
+
+// copied from core/utils/
+func sanitizeTemplateNode(node *apiv1.Node, nodeGroup string, ignoredTaints taints.TaintKeySet) (*apiv1.Node, errors.AutoscalerError) {
+	newNode := node.DeepCopy()
+	nodeName := fmt.Sprintf("template-node-for-%s-%d", nodeGroup, rand.Int63())
+	newNode.Labels = make(map[string]string, len(node.Labels))
+	for k, v := range node.Labels {
+		if k != apiv1.LabelHostname {
+			newNode.Labels[k] = v
+		} else {
+			newNode.Labels[k] = nodeName
+		}
+	}
+	newNode.Name = nodeName
+	newNode.Spec.Taints = taints.SanitizeTaints(newNode.Spec.Taints, ignoredTaints)
+	return newNode, nil
+}
+
+// CleanUp cleans up processor's internal structures.
+func (p *TemplateOnlyNodeInfoProvider) CleanUp() {
+	close(p.interrupt)
+}
+
+// NewTemplateOnlyNodeInfoProvider returns a NodeInfoProcessor generating NodeInfos from node group templates.
+func NewTemplateOnlyNodeInfoProvider() *TemplateOnlyNodeInfoProvider {
+	return &TemplateOnlyNodeInfoProvider{
+		nodeInfoCache: make(map[string]*nodeInfoCacheEntry),
+	}
+}

--- a/cluster-autoscaler/processors/datadog/nodeinfosprovider/template_only_node_info_provider_test.go
+++ b/cluster-autoscaler/processors/datadog/nodeinfosprovider/template_only_node_info_provider_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeinfosprovider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+
+	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+
+	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+func TestTemplateOnlyNodeInfoProviderProcess(t *testing.T) {
+	predicateChecker, err := simulator.NewTestPredicateChecker()
+	assert.NoError(t, err)
+
+	tni := schedulerframework.NewNodeInfo()
+	tn := BuildTestNode("tn", 100, 100)
+	tn.SetLabels(map[string]string{apiv1.LabelTopologyZone: "planet-earth"})
+	tni.SetNode(tn)
+
+	provider1 := testprovider.NewTestAutoprovisioningCloudProvider(
+		nil, nil, nil, nil, nil,
+		map[string]*schedulerframework.NodeInfo{"ng1": tni, "ng2": tni})
+	provider1.AddNodeGroup("ng1", 1, 10, 1)
+	provider1.AddNodeGroup("ng2", 2, 20, 2)
+
+	processor := NewTemplateOnlyNodeInfoProvider()
+	res, err := processor.GetNodeInfosForGroups(
+		nil,
+		nil,
+		provider1,
+		nil,
+		nil,
+		predicateChecker,
+		nil,
+	)
+
+	// nodegroups providing templates
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(res))
+	assert.Contains(t, res, "ng1")
+	assert.Contains(t, res, "ng2")
+	assert.Contains(t, res["ng1"].Node().GetLabels(), apiv1.LabelZoneFailureDomain)
+	assert.Equal(t, res["ng1"].Node().GetLabels()[apiv1.LabelZoneFailureDomain], "planet-earth")
+}

--- a/cluster-autoscaler/processors/datadog/pods/filter_long_pending.go
+++ b/cluster-autoscaler/processors/datadog/pods/filter_long_pending.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+  Ensures pods pending for a long time are retried at a slower pace:
+  * We don't want those long pending to slow down scale-up for fresh pods.
+  * If one of those is a pod causing a runaway infinite upscale, we want to give
+    autoscaler some slack time to recover from cooldown, and reap unused nodes.
+*/
+
+package pods
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+
+	apiv1 "k8s.io/api/core/v1"
+	klog "k8s.io/klog/v2"
+)
+
+const maxDistinctWorkloadsHavingPendingPods = 50
+
+var now = time.Now // unit tests
+
+type pendingTracker struct {
+	firstSeen time.Time
+	lastTried time.Time
+}
+
+type filterOutLongPending struct {
+	seen map[types.UID]*pendingTracker
+}
+
+// NewFilterOutLongPending returns a processor slowing down retries on long pending pods
+func NewFilterOutLongPending() *filterOutLongPending {
+	return &filterOutLongPending{
+		seen: make(map[types.UID]*pendingTracker),
+	}
+}
+
+// CleanUp tears down the FilterOutLongPending processor
+func (p *filterOutLongPending) CleanUp() {}
+
+// Process slows down upscales retries on long pending pods
+func (p *filterOutLongPending) Process(ctx *context.AutoscalingContext, pending []*apiv1.Pod) ([]*apiv1.Pod, error) {
+	longPendingBackoff := ctx.AutoscalingOptions.ScaleDownDelayAfterAdd * 2
+
+	currentPods := make(map[types.UID]struct{}, len(pending))
+	allowedPods := make([]*apiv1.Pod, 0)
+
+	distinctWorkloadsCount := countDistinctOwnerReferences(pending)
+	if distinctWorkloadsCount > maxDistinctWorkloadsHavingPendingPods {
+		klog.Warningf("detected pending pods from too many (%d) distinct workloads:"+
+			" disabling backoff on long pending pods", distinctWorkloadsCount)
+		return pending, nil
+	}
+
+	for _, pod := range pending {
+		currentPods[pod.UID] = struct{}{}
+		if _, found := p.seen[pod.UID]; !found {
+			p.seen[pod.UID] = &pendingTracker{
+				firstSeen: now(),
+				lastTried: now(),
+			}
+		}
+
+		if p.seen[pod.UID].firstSeen.Add(longPendingCutoff).Before(now()) {
+			deadline := p.seen[pod.UID].lastTried.Add(longPendingBackoff)
+			if deadline.After(now()) {
+				klog.Warningf("ignoring long pending pod %s/%s until %s",
+					pod.GetNamespace(), pod.GetName(), deadline)
+				continue
+			}
+		}
+		p.seen[pod.UID].lastTried = now()
+
+		allowedPods = append(allowedPods, pod)
+	}
+
+	for uid := range p.seen {
+		if _, found := currentPods[uid]; !found {
+			delete(p.seen, uid)
+		}
+	}
+
+	return allowedPods, nil
+}

--- a/cluster-autoscaler/processors/datadog/pods/filter_long_pending_test.go
+++ b/cluster-autoscaler/processors/datadog/pods/filter_long_pending_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pods
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+)
+
+var testScaleDownDelay = time.Minute
+
+var testCtx = &context.AutoscalingContext{
+	AutoscalingOptions: config.AutoscalingOptions{
+		ScaleDownDelayAfterAdd: testScaleDownDelay,
+	},
+}
+
+func TestFilterOutLongPending(t *testing.T) {
+	set1 := buildPendingPods(5, "a")
+	set2 := buildPendingPods(2, "b")
+	set1and2 := append(set1, set2...)
+	largeset := buildPendingPods(2*maxDistinctWorkloadsHavingPendingPods, "c")
+
+	tests := []struct {
+		name            string
+		podsInFirstCall []*apiv1.Pod
+		podsInNextCall  []*apiv1.Pod
+		firstCallDelay  time.Duration
+		nextCallDelay   time.Duration
+		expected        []*apiv1.Pod
+	}{
+		{"none filtered when no long pending pods", set1, set1and2, time.Minute, testScaleDownDelay, set1and2},
+		{"long pending pods are filtered out", set1, set1and2, 2 * longPendingCutoff, testScaleDownDelay / 2, set2},
+		{"retry long pending after some time", set1, set1and2, 2 * longPendingCutoff, testScaleDownDelay * 2, set1and2},
+		{"circuit-break and on huge backlog", largeset, largeset, 2 * longPendingCutoff, testScaleDownDelay / 2, largeset},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now = time.Now
+			fp := NewFilterOutLongPending()
+
+			actual, err := fp.Process(testCtx, tt.podsInFirstCall)
+			assert.NoError(t, err)
+
+			now = func() time.Time { return time.Now().Add(tt.firstCallDelay) }
+			actual, err = fp.Process(testCtx, tt.podsInNextCall)
+			assert.ElementsMatch(t, actual, tt.podsInNextCall, "unexpected pods filtered out")
+			assert.NoError(t, err)
+
+			now = func() time.Time { return time.Now().Add(tt.firstCallDelay).Add(tt.nextCallDelay) }
+			actual, err = fp.Process(testCtx, tt.podsInNextCall)
+			assert.ElementsMatch(t, actual, tt.expected, "unexpected pods filtered out")
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func buildPendingPods(count int, setName string) []*apiv1.Pod {
+	var result []*apiv1.Pod
+	trueish := true
+	for i := 0; i < count; i++ {
+		result = append(result, &apiv1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				UID: types.UID(fmt.Sprintf("%s-%d", setName, i)),
+				OwnerReferences: []metav1.OwnerReference{{
+					UID:        types.UID(fmt.Sprintf("%s-%d", setName, i)),
+					Name:       fmt.Sprintf("%s-%d", setName, i),
+					Controller: &trueish,
+				}},
+			},
+		})
+	}
+	return result
+}

--- a/cluster-autoscaler/processors/datadog/pods/filter_schedulable.go
+++ b/cluster-autoscaler/processors/datadog/pods/filter_schedulable.go
@@ -183,6 +183,11 @@ func isLivingNode(nodeInfo *schedulerframework.NodeInfo) bool {
 		return true
 	}
 
+	// fresh but not yet ready nodes should be considered as live nodes
+	if node.CreationTimestamp.Time.Add(5 * time.Minute).After(time.Now()) {
+		return true
+	}
+
 	for _, cond := range node.Status.Conditions {
 		if cond.Type != apiv1.NodeReady {
 			continue

--- a/cluster-autoscaler/processors/datadog/pods/filter_schedulable.go
+++ b/cluster-autoscaler/processors/datadog/pods/filter_schedulable.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pods
+
+import (
+	"sort"
+	"time"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	klog "k8s.io/klog/v2"
+
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/core/utils"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+type filterOutSchedulable struct {
+	schedulablePodsNodeHints map[types.UID]string
+}
+
+// NewFilterOutSchedulable creates a PodListProcessor filtering out schedulable pods
+func NewFilterOutSchedulable() *filterOutSchedulable {
+	return &filterOutSchedulable{
+		schedulablePodsNodeHints: make(map[types.UID]string),
+	}
+}
+
+// Process filters out pods which are schedulable from list of unschedulable pods.
+func (p *filterOutSchedulable) Process(
+	context *context.AutoscalingContext,
+	unschedulablePods []*apiv1.Pod) ([]*apiv1.Pod, error) {
+	// We need to check whether pods marked as unschedulable are actually unschedulable.
+	// It's likely we added a new node and the scheduler just haven't managed to put the
+	// pod on in yet. In this situation we don't want to trigger another scale-up.
+	//
+	// It's also important to prevent uncontrollable cluster growth if CA's simulated
+	// scheduler differs in opinion with real scheduler. Example of such situation:
+	// - CA and Scheduler has slightly different configuration
+	// - Scheduler can't schedule a pod and marks it as unschedulable
+	// - CA added a node which should help the pod
+	// - Scheduler doesn't schedule the pod on the new node
+	//   because according to it logic it doesn't fit there
+	// - CA see the pod is still unschedulable, so it adds another node to help it
+	//
+	// With the check enabled the last point won't happen because CA will ignore a pod
+	// which is supposed to schedule on an existing node.
+	unschedulablePodsToHelp, err := p.filterOutSchedulableByPacking(unschedulablePods, context.ClusterSnapshot,
+		context.PredicateChecker)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(unschedulablePodsToHelp) != len(unschedulablePods) {
+		klog.V(2).Info("Schedulable pods present")
+		context.ProcessorCallbacks.DisableScaleDownForLoop()
+	} else {
+		klog.V(4).Info("No schedulable pods")
+	}
+	return unschedulablePodsToHelp, nil
+}
+
+func (p *filterOutSchedulable) CleanUp() {
+}
+
+// filterOutSchedulableByPacking checks whether pods from <unschedulableCandidates> marked as
+// unschedulable can be scheduled on free capacity on existing nodes by trying to pack the pods. It
+// tries to pack the higher priority pods first. It takes into account pods that are bound to node
+// and will be scheduled after lower priority pod preemption.
+func (p *filterOutSchedulable) filterOutSchedulableByPacking(
+	unschedulableCandidates []*apiv1.Pod,
+	clusterSnapshot simulator.ClusterSnapshot,
+	predicateChecker simulator.PredicateChecker) ([]*apiv1.Pod, error) {
+	unschedulablePodsCache := make(utils.PodSchedulableMap)
+
+	// Sort unschedulable pods by importance
+	sort.Slice(unschedulableCandidates, func(i, j int) bool {
+		return moreImportantPod(unschedulableCandidates[i], unschedulableCandidates[j])
+	})
+
+	// Pods which remain unschedulable
+	var unschedulablePods []*apiv1.Pod
+
+	// Try to schedule based on hints
+	podsFilteredUsingHints := 0
+	podsToCheckAgainstAllNodes := make([]*apiv1.Pod, 0, len(unschedulableCandidates))
+	for _, pod := range unschedulableCandidates {
+		scheduledOnHintedNode := false
+		if hintedNodeName, hintFound := p.schedulablePodsNodeHints[pod.UID]; hintFound {
+			nodeInfo, _ := clusterSnapshot.NodeInfos().Get(hintedNodeName)
+			if predicateChecker.CheckPredicates(clusterSnapshot, pod, hintedNodeName) == nil && isLivingNode(nodeInfo) {
+				// We treat predicate error and missing node error here in the same way
+				scheduledOnHintedNode = true
+				podsFilteredUsingHints++
+				klog.V(4).Infof("Pod %s.%s marked as unschedulable can be scheduled on node %s (based on hinting). Ignoring"+
+					" in scale up.", pod.Namespace, pod.Name, hintedNodeName)
+
+				if err := clusterSnapshot.AddPod(pod, hintedNodeName); err != nil {
+					return nil, err
+				}
+			}
+		}
+
+		if !scheduledOnHintedNode {
+			podsToCheckAgainstAllNodes = append(podsToCheckAgainstAllNodes, pod)
+			delete(p.schedulablePodsNodeHints, pod.UID)
+		}
+	}
+	klog.V(4).Infof("Filtered out %d pods using hints", podsFilteredUsingHints)
+
+	// Cleanup hints map
+	foundPods := make(map[types.UID]bool)
+	for _, pod := range unschedulableCandidates {
+		foundPods[pod.UID] = true
+	}
+	for hintedPodUID := range p.schedulablePodsNodeHints {
+		if !foundPods[hintedPodUID] {
+			delete(p.schedulablePodsNodeHints, hintedPodUID)
+		}
+	}
+
+	// Try to bin pack remaining pods
+	unschedulePodsCacheHitCounter := 0
+	for _, pod := range podsToCheckAgainstAllNodes {
+		_, found := unschedulablePodsCache.Get(pod)
+		if found {
+			// Cache hit for similar pod; assuming unschedulable without running predicates
+			unschedulablePods = append(unschedulablePods, pod)
+			unschedulePodsCacheHitCounter++
+			continue
+		}
+		nodeName, err := predicateChecker.FitsAnyNodeMatching(clusterSnapshot, pod, func(nodeInfo *schedulerframework.NodeInfo) bool {
+			return isLivingNode(nodeInfo)
+		})
+		if err == nil {
+			klog.V(4).Infof("Pod %s.%s marked as unschedulable can be scheduled on node %s. Ignoring"+
+				" in scale up.", pod.Namespace, pod.Name, nodeName)
+			if err := clusterSnapshot.AddPod(pod, nodeName); err != nil {
+				return nil, err
+			}
+			// Store hint for pod placement
+			p.schedulablePodsNodeHints[pod.UID] = nodeName
+		} else {
+			unschedulablePods = append(unschedulablePods, pod)
+			// cache negative result
+			unschedulablePodsCache.Set(pod, nil)
+		}
+	}
+	klog.V(4).Infof("%v pods were kept as unschedulable based on caching", unschedulePodsCacheHitCounter)
+	klog.V(4).Infof("%v pods marked as unschedulable can be scheduled.", len(unschedulableCandidates)-len(unschedulablePods))
+	return unschedulablePods, nil
+}
+
+// filter out dead nodes (having "unknown" NodeReady condition for over 5mn), so we can ignore them if hinted.
+// Needed for 1.10 clusters, until we set TaintBasedEvictions feature gate to "true" there (already enabled
+// by default on clusters using k8s v1.14 and up): TaintBasedEvictions places a node.kubernetes.io/unreachable
+// taint on dead nodes, that helps the CA to consider them unschedulable (unless explicitly tolerated).
+func isLivingNode(nodeInfo *schedulerframework.NodeInfo) bool {
+	if nodeInfo == nil {
+		// we only care about filtering out nodes having "unknown" status.
+		return true
+	}
+
+	node := nodeInfo.Node()
+	if node == nil && node.Status.Conditions == nil {
+		return true
+	}
+
+	for _, cond := range node.Status.Conditions {
+		if cond.Type != apiv1.NodeReady {
+			continue
+		}
+		if cond.Status != apiv1.ConditionUnknown {
+			continue
+		}
+		if cond.LastTransitionTime.Time.Add(5 * time.Minute).Before(time.Now()) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func moreImportantPod(pod1, pod2 *apiv1.Pod) bool {
+	// based on schedulers MoreImportantPod but does not compare Pod.Status.StartTime which does not make sense
+	// for unschedulable pods
+	p1 := GetPodPriority(pod1)
+	p2 := GetPodPriority(pod2)
+	return p1 > p2
+}
+
+// GetPodPriority returns priority of the given pod. -- copied from v1.19:k8s.io/kubernetes/pkg/api/v1/pod
+// to ease upgrade to 1.21. Once upgraded, use GetPodPriority from
+func GetPodPriority(pod *apiv1.Pod) int32 {
+	if pod.Spec.Priority != nil {
+		return *pod.Spec.Priority
+	}
+	// When priority of a running pod is nil, it means it was created at a time
+	// that there was no global default priority class and the priority class
+	// name of the pod was empty. So, we resolve to the static default priority.
+	return 0
+}

--- a/cluster-autoscaler/processors/datadog/pods/filter_schedulable.go
+++ b/cluster-autoscaler/processors/datadog/pods/filter_schedulable.go
@@ -67,7 +67,8 @@ func (p *filterOutSchedulable) Process(
 		return nil, err
 	}
 
-	if len(unschedulablePodsToHelp) != len(unschedulablePods) {
+	if len(filterByAge(unschedulablePodsToHelp, youngerThan, longPendingCutoff)) !=
+		len(filterByAge(unschedulablePods, youngerThan, longPendingCutoff)) {
 		klog.V(2).Info("Schedulable pods present")
 		context.ProcessorCallbacks.DisableScaleDownForLoop()
 	} else {

--- a/cluster-autoscaler/processors/datadog/pods/filter_schedulable_test.go
+++ b/cluster-autoscaler/processors/datadog/pods/filter_schedulable_test.go
@@ -1,0 +1,271 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pods
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterOutSchedulableByPacking(t *testing.T) {
+	// TODO(scheduler_framework_integration) extend/cleanup the test
+	// - add more nodes
+	// - add better naming for pods/scenarios
+
+	p2Owner := metav1.OwnerReference{
+		UID:        "controler_a",
+		Controller: pointer.BoolPtr(true),
+	}
+
+	p1 := BuildTestPod("p1", 1500, 200000)
+
+	// define owner to enable caching
+	p2_1 := BuildTestPod("p2_1", 3000, 200000)
+	p2_1.ObjectMeta.OwnerReferences = append(p2_1.ObjectMeta.OwnerReferences, p2Owner)
+	p2_2 := BuildTestPod("p2_2", 3000, 200000)
+	p2_2.ObjectMeta.OwnerReferences = append(p2_2.ObjectMeta.OwnerReferences, p2Owner)
+
+	p3_1 := BuildTestPod("p3_1", 300, 200000)
+	p3_2 := BuildTestPod("p3_2", 300, 200000)
+
+	scheduledPod1 := BuildTestPod("s1", 100, 200000)
+	scheduledPod1.Spec.NodeName = "node1"
+	scheduledPod2 := BuildTestPod("s2", 1500, 200000)
+	scheduledPod2.Spec.NodeName = "node1"
+
+	podWaitingForPreemption := BuildTestPod("w1", 1500, 200000)
+	var priority100 int32 = 100
+	podWaitingForPreemption.Spec.Priority = &priority100
+	podWaitingForPreemption.Status.NominatedNodeName = "node1"
+
+	p4 := BuildTestPod("p4", 1800, 200000)
+	p4.Spec.Priority = &priority100
+
+	node := BuildTestNode("node1", 2000, 2000000)
+	SetNodeReadyState(node, true, time.Time{})
+
+	tests := []struct {
+		name                    string
+		nodes                   []*apiv1.Node
+		scheduledPods           []*apiv1.Pod
+		pendingPods             []*apiv1.Pod
+		expectedFilteredOutPods []*apiv1.Pod
+	}{
+		{
+			name:                    "scenario 1",
+			nodes:                   []*apiv1.Node{node},
+			scheduledPods:           []*apiv1.Pod{scheduledPod1},
+			pendingPods:             []*apiv1.Pod{p1, p2_1, p2_2, p3_1, p3_2},
+			expectedFilteredOutPods: []*apiv1.Pod{p1, p3_1},
+		},
+		{
+			name:                    "scenario 2",
+			nodes:                   []*apiv1.Node{node},
+			scheduledPods:           []*apiv1.Pod{scheduledPod1, scheduledPod2},
+			pendingPods:             []*apiv1.Pod{p1, p2_1, p2_2, p3_1, p3_2},
+			expectedFilteredOutPods: []*apiv1.Pod{p3_1},
+		},
+		{
+			name:                    "scenario 3",
+			nodes:                   []*apiv1.Node{node},
+			scheduledPods:           []*apiv1.Pod{scheduledPod1},
+			pendingPods:             []*apiv1.Pod{p1, p2_1, p2_2, p3_1, p3_2, p4},
+			expectedFilteredOutPods: []*apiv1.Pod{p4},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			predicateChecker, err := simulator.NewTestPredicateChecker()
+			clusterSnapshot := simulator.NewBasicClusterSnapshot()
+
+			for _, node := range tt.nodes {
+				err := clusterSnapshot.AddNode(node)
+				assert.NoError(t, err)
+			}
+
+			for _, pod := range tt.scheduledPods {
+				err = clusterSnapshot.AddPod(pod, pod.Spec.NodeName)
+				assert.NoError(t, err)
+			}
+
+			filterOutSchedulablePodListProcessor := NewFilterOutSchedulable()
+
+			err = clusterSnapshot.Fork()
+			assert.NoError(t, err)
+
+			var expectedPodsInSnapshot = tt.scheduledPods
+			for _, pod := range tt.expectedFilteredOutPods {
+				expectedPodsInSnapshot = append(expectedPodsInSnapshot, pod)
+			}
+
+			var expectedPendingPods []*apiv1.Pod
+			for _, pod := range tt.pendingPods {
+				filteredOut := false
+				for _, filteredOutPod := range tt.expectedFilteredOutPods {
+					if pod == filteredOutPod {
+						filteredOut = true
+					}
+				}
+				if !filteredOut {
+					expectedPendingPods = append(expectedPendingPods, pod)
+				}
+			}
+
+			stillPendingPods, err := filterOutSchedulablePodListProcessor.filterOutSchedulableByPacking(tt.pendingPods, clusterSnapshot, predicateChecker)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, stillPendingPods, expectedPendingPods, "pending pods differ")
+
+			// Check if snapshot was correctly modified
+			nodeInfos, err := clusterSnapshot.NodeInfos().List()
+			assert.NoError(t, err)
+			var podsInSnapshot []*apiv1.Pod
+			for _, nodeInfo := range nodeInfos {
+				for _, podInfo := range nodeInfo.Pods {
+					podsInSnapshot = append(podsInSnapshot, podInfo.Pod)
+				}
+			}
+			assert.ElementsMatch(t, podsInSnapshot, expectedPodsInSnapshot, "pods in snapshot differ")
+
+			// Verify hints map; it is very whitebox but better than nothing
+			var podUidsInHintsMap []types.UID
+			for uid := range filterOutSchedulablePodListProcessor.schedulablePodsNodeHints {
+				podUidsInHintsMap = append(podUidsInHintsMap, uid)
+			}
+			var expectedFilteredOutPodUids []types.UID
+			for _, pod := range tt.expectedFilteredOutPods {
+				expectedFilteredOutPodUids = append(expectedFilteredOutPodUids, pod.UID)
+			}
+			assert.ElementsMatch(t, expectedFilteredOutPodUids, podUidsInHintsMap)
+
+			// reset snapshot to initial state and run filterOutSchedulableByPacking with hinting map filled in
+			err = clusterSnapshot.Revert()
+			assert.NoError(t, err)
+			err = clusterSnapshot.Fork()
+			assert.NoError(t, err)
+
+			stillPendingPods, err = filterOutSchedulablePodListProcessor.filterOutSchedulableByPacking(tt.pendingPods, clusterSnapshot, predicateChecker)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, stillPendingPods, expectedPendingPods, "pending pods differ (with hints map)")
+
+		})
+	}
+}
+
+func BenchmarkFilterOutSchedulableByPacking(b *testing.B) {
+	// All pending pods in this scenario are unschedulable - predicates will fail.
+	tests := []struct {
+		name          string
+		nodes         int
+		scheduledPods int
+		pendingPods   int
+	}{
+		{
+			name:          "nothing",
+			nodes:         1,
+			scheduledPods: 30,
+			pendingPods:   1000,
+		},
+		{
+			name:          "small",
+			nodes:         10,
+			scheduledPods: 300,
+			pendingPods:   1000,
+		},
+		{
+			name:          "medium",
+			nodes:         100,
+			scheduledPods: 3000,
+			pendingPods:   1000,
+		},
+		{
+			name:          "large",
+			nodes:         200,
+			scheduledPods: 200,
+			pendingPods:   60000,
+		},
+		{
+			name:          "1k",
+			nodes:         1000,
+			scheduledPods: 1000,
+			pendingPods:   12000,
+		},
+	}
+	snapshots := map[string]func() simulator.ClusterSnapshot{
+		"basic": func() simulator.ClusterSnapshot { return simulator.NewBasicClusterSnapshot() },
+		"delta": func() simulator.ClusterSnapshot { return simulator.NewDeltaClusterSnapshot() },
+	}
+	for snapshotName, snapshotFactory := range snapshots {
+		for _, tc := range tests {
+			b.Run(fmt.Sprintf("%s: %d nodes %d scheduled %d pending", snapshotName, tc.nodes, tc.scheduledPods, tc.pendingPods), func(b *testing.B) {
+				pendingPods := make([]*apiv1.Pod, tc.pendingPods, tc.pendingPods)
+				for i := 0; i < tc.pendingPods; i++ {
+					pendingPods[i] = BuildTestPod(fmt.Sprintf("p-%d", i), 1000, 2000000)
+				}
+				nodes := make([]*apiv1.Node, tc.nodes, tc.nodes)
+				for i := 0; i < tc.nodes; i++ {
+					nodes[i] = BuildTestNode(fmt.Sprintf("n-%d", i), 2000, 200000)
+					SetNodeReadyState(nodes[i], true, time.Time{})
+				}
+				scheduledPods := make([]*apiv1.Pod, tc.scheduledPods, tc.scheduledPods)
+				j := 0
+				for i := 0; i < tc.scheduledPods; i++ {
+					scheduledPods[i] = BuildTestPod(fmt.Sprintf("s-%d", i), 1000, 200000)
+					scheduledPods[i].Spec.NodeName = nodes[j].Name
+					j++
+					if j >= tc.nodes {
+						j = 0
+					}
+				}
+
+				predicateChecker, err := simulator.NewTestPredicateChecker()
+				assert.NoError(b, err)
+
+				clusterSnapshot := snapshotFactory()
+				if err := clusterSnapshot.AddNodes(nodes); err != nil {
+					assert.NoError(b, err)
+				}
+
+				for _, pod := range scheduledPods {
+					if err := clusterSnapshot.AddPod(pod, pod.Spec.NodeName); err != nil {
+						assert.NoError(b, err)
+					}
+				}
+				b.ResetTimer()
+
+				for i := 0; i < b.N; i++ {
+					filterOutSchedulablePodListProcessor := NewFilterOutSchedulable()
+					if stillPending, err := filterOutSchedulablePodListProcessor.filterOutSchedulableByPacking(pendingPods, clusterSnapshot, predicateChecker); err != nil {
+						assert.NoError(b, err)
+					} else if len(stillPending) < tc.pendingPods {
+						assert.Equal(b, len(stillPending), tc.pendingPods)
+					}
+				}
+			})
+		}
+	}
+}

--- a/cluster-autoscaler/processors/datadog/pods/processor.go
+++ b/cluster-autoscaler/processors/datadog/pods/processor.go
@@ -37,6 +37,7 @@ func NewFilteringPodListProcessor() *filteringPodListProcessor {
 	return &filteringPodListProcessor{
 		transforms: []proc.PodListProcessor{
 			NewTransformLocalData(),
+			NewTransformDataNodes(),
 		},
 		filters: []proc.PodListProcessor{
 			NewFilterOutLongPending(),

--- a/cluster-autoscaler/processors/datadog/pods/processor.go
+++ b/cluster-autoscaler/processors/datadog/pods/processor.go
@@ -39,6 +39,7 @@ func NewFilteringPodListProcessor() *filteringPodListProcessor {
 			NewTransformLocalData(),
 		},
 		filters: []proc.PodListProcessor{
+			NewFilterOutLongPending(),
 			NewFilterOutSchedulable(),
 		},
 	}

--- a/cluster-autoscaler/processors/datadog/pods/processor.go
+++ b/cluster-autoscaler/processors/datadog/pods/processor.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pods
+
+import (
+	"time"
+
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/metrics"
+	proc "k8s.io/autoscaler/cluster-autoscaler/processors/pods"
+
+	apiv1 "k8s.io/api/core/v1"
+	klog "k8s.io/klog/v2"
+)
+
+type filteringPodListProcessor struct {
+	transforms []proc.PodListProcessor
+	filters    []proc.PodListProcessor
+}
+
+// NewFilteringPodListProcessor returns an aggregated podlist processor
+func NewFilteringPodListProcessor() *filteringPodListProcessor {
+	return &filteringPodListProcessor{
+		transforms: []proc.PodListProcessor{
+			NewTransformLocalData(),
+		},
+		filters: []proc.PodListProcessor{
+			NewFilterOutSchedulable(),
+		},
+	}
+}
+
+// CleanUp tears down all aggreated podlist processors
+func (p *filteringPodListProcessor) CleanUp() {
+	for _, transform := range p.transforms {
+		transform.CleanUp()
+	}
+	for _, filter := range p.filters {
+		filter.CleanUp()
+	}
+}
+
+// Process runs all podlists processors
+func (p *filteringPodListProcessor) Process(ctx *context.AutoscalingContext, pending []*apiv1.Pod) ([]*apiv1.Pod, error) {
+	klog.V(4).Infof("Filtering pending pods")
+	start := time.Now()
+
+	var err error
+
+	for _, transform := range p.transforms {
+		pending, err = transform.Process(ctx, pending)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	unschedulablePodsToHelp := make([]*apiv1.Pod, len(pending))
+	copy(unschedulablePodsToHelp, pending)
+	for _, filter := range p.filters {
+		unschedulablePodsToHelp, err = filter.Process(ctx, unschedulablePodsToHelp)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	metrics.UpdateDurationFromStart(metrics.FilterOutSchedulable, start)
+	return unschedulablePodsToHelp, nil
+}

--- a/cluster-autoscaler/processors/datadog/pods/processor_test.go
+++ b/cluster-autoscaler/processors/datadog/pods/processor_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pods
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	proc "k8s.io/autoscaler/cluster-autoscaler/processors/pods"
+
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Test processors frontend by ensuring pipelines are properly wired and chained.
+// Effective filters and transforms are tested individually in other files.
+
+func TestFilteringPodListProcessor(t *testing.T) {
+	fp := filteringPodListProcessor{
+		transforms: []proc.PodListProcessor{
+			&testTransformProcessor{
+				suffix: "-renamed",
+			},
+			&testTransformProcessor{
+				suffix: "-again",
+			},
+		},
+		filters: []proc.PodListProcessor{
+			&testFilterProcessor{
+				filteredName: "p2-renamed-again",
+			},
+		},
+	}
+
+	ctx := &context.AutoscalingContext{}
+
+	in := []*apiv1.Pod{newPod("p1"), newPod("p2")}
+	expected := []*apiv1.Pod{newPod("p1-renamed-again")}
+
+	actual, err := fp.Process(ctx, in)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, actual, expected, "filtered pods differ")
+}
+
+func newPod(name string) *apiv1.Pod {
+	return &apiv1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name}}
+}
+
+type testTransformProcessor struct {
+	suffix string
+}
+
+func (p *testTransformProcessor) Process(ctx *context.AutoscalingContext, pending []*apiv1.Pod) ([]*apiv1.Pod, error) {
+	for _, pod := range pending {
+		pod.SetName(fmt.Sprintf("%s%s", pod.GetName(), p.suffix))
+	}
+	return pending, nil
+}
+
+func (p *testTransformProcessor) CleanUp() {}
+
+type testFilterProcessor struct {
+	filteredName string
+}
+
+func (p *testFilterProcessor) Process(ctx *context.AutoscalingContext, pending []*apiv1.Pod) ([]*apiv1.Pod, error) {
+	var result []*apiv1.Pod
+	for _, pod := range pending {
+		if pod.GetName() != p.filteredName {
+			result = append(result, pod)
+		}
+	}
+	return result, nil
+}
+
+func (p *testFilterProcessor) CleanUp() {}

--- a/cluster-autoscaler/processors/datadog/pods/transform_local_data.go
+++ b/cluster-autoscaler/processors/datadog/pods/transform_local_data.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+  This provides support for local-data persistent volumes, by two means:
+  * Removes volumes using "local-data" from the internal pods copy, for the
+    duration of the current autoscaler RunOnce loop. local-data volumes (as
+    any volume using a no-provisioner storage class) breaks the VolumeBinding
+    predicate used during Scheduler Framework's evaluations.
+  * Injects a custom resource request to pods having "local-data" volumes.
+    Our autoscaler fork is placing the same resource on NodeInfo templates
+    built from ASG/MIG/VMSS when they offer nodes with local-data storage.
+    Those virtual NodeInfos are used when the autoscaler evaluates upscale
+    candidates. Injecting those requests on pods allows us to upscale only
+    nodes having local data, and to know those nodes can host a single pod
+    requesting a local-data volume (because allocatable qty = request = 1).
+
+  Caveats:
+  * That's obviously not upstreamable
+  * With that resource req, none of the existing real nodes can be considered
+    by autoscaler as schedulable for pods requesting local-data volumes: the
+    "storageclass/local-data" resource is only available on virtual nodes built
+    from asg templates (so, during upscale simulations and for upcoming nodes),
+    but not at "filter out pods schedulables on existing real nodes" phase.
+    Hence the need for an other patch: once those nodes just became ready but
+    the pod is not scheduled on them yet (eg. when their local data volume
+    isn't built or bound yet): the autoscaler wouldn't consider those fresh
+    nodes (now evaluated by using nodeInfos built from real/live nodes)
+    suitable for their pendind pods anymore, since now the nodes don't have
+    the requested custom resource. Which would lead to spurious re-upscales
+    during the "node became Ready -> pod now scheduled to that node" phase.
+  * Using that hack forces the use nodeinfos built from asg templates, rather
+    than from real world nodes (as op. to upstream behaviour). Which we do
+    also for other reasons anyway (scale from zero + balance similar).
+*/
+
+package pods
+
+import (
+	"time"
+
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/datadog/common"
+
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/fields"
+	client "k8s.io/client-go/kubernetes"
+	v1lister "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	klog "k8s.io/klog/v2"
+)
+
+type transformLocalData struct {
+	pvcLister   v1lister.PersistentVolumeClaimLister
+	stopChannel chan struct{}
+}
+
+// NewTransformLocalData instantiate a transformLocalData processor
+func NewTransformLocalData() *transformLocalData {
+	return &transformLocalData{
+		stopChannel: make(chan struct{}),
+	}
+}
+
+// CleanUp shuts down the pv lister
+func (p *transformLocalData) CleanUp() {
+	close(p.stopChannel)
+}
+
+// Process replace volumes to local-data pv by our custom resource
+func (p *transformLocalData) Process(ctx *context.AutoscalingContext, pods []*apiv1.Pod) ([]*apiv1.Pod, error) {
+	if p.pvcLister == nil {
+		p.pvcLister = NewPersistentVolumeClaimLister(ctx.ClientSet, p.stopChannel)
+	}
+
+	for _, po := range pods {
+		var volumes []apiv1.Volume
+		for _, vol := range po.Spec.Volumes {
+			if vol.PersistentVolumeClaim == nil {
+				volumes = append(volumes, vol)
+				continue
+			}
+			pvc, err := p.pvcLister.PersistentVolumeClaims(po.Namespace).Get(vol.PersistentVolumeClaim.ClaimName)
+			if err != nil {
+				if !apierrors.IsNotFound(err) {
+					klog.Warningf("failed to fetch pvc for %s/%s: %v", po.GetNamespace(), po.GetName(), err)
+				}
+				volumes = append(volumes, vol)
+				continue
+			}
+			if *pvc.Spec.StorageClassName != "local-data" {
+				volumes = append(volumes, vol)
+				continue
+			}
+
+			if len(po.Spec.Containers[0].Resources.Requests) == 0 {
+				po.Spec.Containers[0].Resources.Requests = apiv1.ResourceList{}
+			}
+			if len(po.Spec.Containers[0].Resources.Limits) == 0 {
+				po.Spec.Containers[0].Resources.Limits = apiv1.ResourceList{}
+			}
+
+			po.Spec.Containers[0].Resources.Requests[common.DatadogLocalDataResource] = common.DatadogLocalDataQuantity.DeepCopy()
+			po.Spec.Containers[0].Resources.Limits[common.DatadogLocalDataResource] = common.DatadogLocalDataQuantity.DeepCopy()
+		}
+		po.Spec.Volumes = volumes
+	}
+
+	return pods, nil
+}
+
+// NewPersistentVolumeClaimLister builds a persistentvolumeclaim lister.
+func NewPersistentVolumeClaimLister(kubeClient client.Interface, stopchannel <-chan struct{}) v1lister.PersistentVolumeClaimLister {
+	listWatcher := cache.NewListWatchFromClient(kubeClient.CoreV1().RESTClient(), "persistentvolumeclaims", apiv1.NamespaceAll, fields.Everything())
+	store, reflector := cache.NewNamespaceKeyedIndexerAndReflector(listWatcher, &apiv1.PersistentVolumeClaim{}, time.Hour)
+	lister := v1lister.NewPersistentVolumeClaimLister(store)
+	go reflector.Run(stopchannel)
+	return lister
+}

--- a/cluster-autoscaler/processors/datadog/pods/transform_local_data_test.go
+++ b/cluster-autoscaler/processors/datadog/pods/transform_local_data_test.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pods
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/datadog/common"
+	v1lister "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	testRemoteClass    = "remote-data"
+	testLocalClass     = "local-data"
+	testNamespace      = "foons"
+	testEmptyResources = corev1.ResourceList{}
+	testLdResources    = corev1.ResourceList{
+		common.DatadogLocalDataResource: common.DatadogLocalDataQuantity.DeepCopy(),
+	}
+)
+
+func TestTransformLocalDataProcess(t *testing.T) {
+	tests := []struct {
+		name     string
+		pods     []*corev1.Pod
+		pvcs     []*corev1.PersistentVolumeClaim
+		expected []*corev1.Pod
+	}{
+		{
+			"No modification on remote volumes",
+			[]*corev1.Pod{buildPod("pod1", testEmptyResources, testEmptyResources, "pvc-1")},
+			[]*corev1.PersistentVolumeClaim{buildPVC("pvc-1", testRemoteClass)},
+			[]*corev1.Pod{buildPod("pod1", testEmptyResources, testEmptyResources, "pvc-1")},
+		},
+
+		{
+			"Cope with pod not having volumes",
+			[]*corev1.Pod{buildPod("pod1", testEmptyResources, testEmptyResources)},
+			[]*corev1.PersistentVolumeClaim{},
+			[]*corev1.Pod{buildPod("pod1", testEmptyResources, testEmptyResources)},
+		},
+
+		{
+			"local-data volumes are removed, and custom resources added",
+			[]*corev1.Pod{buildPod("pod1", testEmptyResources, testEmptyResources, "pvc-1")},
+			[]*corev1.PersistentVolumeClaim{buildPVC("pvc-1", testLocalClass)},
+			[]*corev1.Pod{buildPod("pod1", testLdResources, testLdResources)},
+		},
+
+		{
+			"mixed local-data and remote volumes don't cause confusion",
+			[]*corev1.Pod{buildPod("pod1", testEmptyResources, testEmptyResources, "pvc-1", "pvc-2", "pvc-3")},
+			[]*corev1.PersistentVolumeClaim{
+				buildPVC("pvc-1", testRemoteClass),
+				buildPVC("pvc-2", testLocalClass),
+				buildPVC("pvc-3", testRemoteClass),
+			},
+			[]*corev1.Pod{buildPod("pod1", testLdResources, testLdResources, "pvc-1", "pvc-3")},
+		},
+
+		{
+			"volumes using missing pvcs are conserved",
+			[]*corev1.Pod{buildPod("pod1", testEmptyResources, testEmptyResources, "pvc-1")},
+			[]*corev1.PersistentVolumeClaim{},
+			[]*corev1.Pod{buildPod("pod1", testEmptyResources, testEmptyResources, "pvc-1")},
+		},
+
+		{
+			"empty pod list don't crash",
+			[]*corev1.Pod{},
+			[]*corev1.PersistentVolumeClaim{},
+			[]*corev1.Pod{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pvcLister, err := newTestPVCLister(tt.pvcs)
+			assert.NoError(t, err)
+
+			tld := transformLocalData{
+				pvcLister: pvcLister,
+			}
+			actual, err := tld.Process(&context.AutoscalingContext{}, tt.pods)
+			assert.NoError(t, err)
+			assert.True(t, apiequality.Semantic.DeepEqual(tt.expected, actual))
+		})
+	}
+
+}
+
+func newTestPVCLister(pvcs []*corev1.PersistentVolumeClaim) (v1lister.PersistentVolumeClaimLister, error) {
+	store := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	for _, pvc := range pvcs {
+		err := store.Add(pvc)
+		if err != nil {
+			return nil, fmt.Errorf("Error adding object to cache: %v", err)
+		}
+	}
+	return v1lister.NewPersistentVolumeClaimLister(store), nil
+}
+
+func buildPod(name string, requests, limits corev1.ResourceList, claimNames ...string) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+		},
+		Spec: corev1.PodSpec{
+			Volumes: []corev1.Volume{},
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: requests,
+						Limits:   limits,
+					},
+				},
+			},
+		},
+	}
+
+	for _, name := range claimNames {
+		pod.Spec.Volumes = append(pod.Spec.Volumes,
+			corev1.Volume{
+				Name: name,
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: name,
+					},
+				},
+			})
+	}
+
+	return pod
+}
+
+func buildPVC(name string, storageClassName string) *corev1.PersistentVolumeClaim {
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &storageClassName,
+		},
+	}
+}

--- a/cluster-autoscaler/processors/datadog/pods/transform_nodes_local_data.go
+++ b/cluster-autoscaler/processors/datadog/pods/transform_nodes_local_data.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+  This hack completes the other sub-processor that add storageclass/local-data
+  custom resources requests to pods requesting local-data.
+
+  Use case being addressed here is: when a node with local-storage just joined,
+  its PV isn't immediately available, and pods that triggered the upscale will
+  remain pending for a moment. The autoscaler might run during that window,
+  evaluate those pods against the just joined nodes, and would consider them
+  unschedulable as the fresh real nodes don't have the custom local-data
+  resource allocatable (as op. to virtual nodes built from ASG templates).
+  Which would cause a spurious re-upscale.
+
+  Decorating those fresh nodes with the requested resources they were expected
+  to offer when created will help the autoscaler to consider them usable for
+  still pending pods, which then won't be flagged as unschedulable and won't
+  trigger an other upscale.
+
+  Theorically all nodes labeled local-storage:true could be injected that custom
+  resource, for a better accuracy. But side effects of that generalisation
+  needs to be evaluated carefully. For instance, absence of the custom resource
+  prevents the autoscaler to even try to repack stateful pods (as they wouldn't
+  fit anywhere). That's why we limit the change to recent local-data nodes for
+  now (later: evaluate if we can safely apply to all local-data real nodes).
+
+  This replaces a previous workaround that did set those new nodes as "unready"
+  until an LVP pod was running there for 90s, but in a way that don't require
+  altering core, and better mimic normal nodes behaviour.
+*/
+
+package pods
+
+import (
+	"time"
+
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/datadog/common"
+
+	apiv1 "k8s.io/api/core/v1"
+)
+
+const (
+	// NodeReadyGraceDelay is time during which we inject custom resource after a node becomes ready
+	NodeReadyGraceDelay = 5 * time.Minute
+)
+
+type transformDataNodes struct{}
+
+// NewTransformDataNodes returns a processor injecting local data custom resource
+func NewTransformDataNodes() *transformDataNodes {
+	return &transformDataNodes{}
+}
+
+// CleanUp tears down a transformDataNodes processor
+func (p *transformDataNodes) CleanUp() {}
+
+// Process injects local data custom resources to nodes offering local-data storage, that became ready since less than 5mn
+func (p *transformDataNodes) Process(ctx *context.AutoscalingContext, pods []*apiv1.Pod) ([]*apiv1.Pod, error) {
+	nodeInfos, err := ctx.ClusterSnapshot.NodeInfos().List()
+	if err != nil {
+		return pods, err
+	}
+
+	for _, nodeInfo := range nodeInfos {
+		node := nodeInfo.Node()
+		if !common.NodeHasLocalData(node) {
+			continue
+		}
+
+		// TODO: evaluate if that age check is really needed
+		readyTimestamp := time.Now()
+		for _, condition := range node.Status.Conditions {
+			if condition.Type == apiv1.NodeReady && condition.Status == apiv1.ConditionTrue {
+				readyTimestamp = condition.LastTransitionTime.Time
+			}
+		}
+		if readyTimestamp.Add(NodeReadyGraceDelay).Before(time.Now()) {
+			continue
+		}
+
+		common.SetNodeLocalDataResource(nodeInfo)
+	}
+
+	return pods, nil
+}

--- a/cluster-autoscaler/processors/datadog/pods/transform_nodes_local_data_test.go
+++ b/cluster-autoscaler/processors/datadog/pods/transform_nodes_local_data_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pods
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/datadog/common"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+)
+
+func TestTransformDataNodesProcess(t *testing.T) {
+	tests := []struct {
+		name     string
+		node     *corev1.Node
+		expected *corev1.Node
+	}{
+
+		{
+			"Resource is added to fresh nodes having local-data label",
+			buildTestNode("a", NodeReadyGraceDelay/2, true, false),
+			buildTestNode("a", NodeReadyGraceDelay/2, true, true),
+		},
+
+		{
+			"Resource is not added to old nodes having local-data label",
+			buildTestNode("b", 2*NodeReadyGraceDelay, true, false),
+			buildTestNode("b", 2*NodeReadyGraceDelay, true, false),
+		},
+
+		{
+			"Resource is not added to new nodes without local-data label",
+			buildTestNode("c", NodeReadyGraceDelay/2, false, false),
+			buildTestNode("c", NodeReadyGraceDelay/2, false, false),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clusterSnapshot := simulator.NewBasicClusterSnapshot()
+			err := clusterSnapshot.AddNode(tt.node)
+			assert.NoError(t, err)
+
+			ctx := &context.AutoscalingContext{
+				ClusterSnapshot: clusterSnapshot,
+			}
+
+			proc := NewTransformDataNodes()
+			_, err = proc.Process(ctx, []*corev1.Pod{})
+			assert.NoError(t, err)
+
+			actual, err := ctx.ClusterSnapshot.NodeInfos().Get(tt.node.GetName())
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.expected.Status.Capacity, actual.Node().Status.Capacity)
+			assert.Equal(t, tt.expected.Status.Allocatable, actual.Node().Status.Allocatable)
+		})
+	}
+
+}
+
+func buildTestNode(name string, age time.Duration, localDataLabel, localDataResource bool) *corev1.Node {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			SelfLink:          fmt.Sprintf("/api/v1/nodes/%s", name),
+			Labels:            map[string]string{},
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-age)),
+		},
+		Status: corev1.NodeStatus{
+			Capacity:    corev1.ResourceList{},
+			Allocatable: corev1.ResourceList{},
+			Conditions: []corev1.NodeCondition{
+				{
+					Type:               corev1.NodeReady,
+					Status:             corev1.ConditionTrue,
+					LastTransitionTime: metav1.NewTime(time.Now().Add(-age)),
+				},
+			},
+		},
+	}
+
+	if localDataLabel {
+		node.ObjectMeta.Labels[common.DatadogLocalStorageLabel] = "true"
+	}
+
+	if localDataResource {
+		node.Status.Capacity[common.DatadogLocalDataResource] = common.DatadogLocalDataQuantity.DeepCopy()
+		node.Status.Allocatable[common.DatadogLocalDataResource] = common.DatadogLocalDataQuantity.DeepCopy()
+	}
+
+	return node
+}

--- a/cluster-autoscaler/processors/datadog/pods/utils.go
+++ b/cluster-autoscaler/processors/datadog/pods/utils.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pods
+
+import (
+	"time"
+
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type ageCondition int
+
+const (
+	longPendingCutoff = time.Hour * 2
+	youngerThan       = iota
+	olderThan         = iota
+)
+
+func countDistinctOwnerReferences(pods []*apiv1.Pod) int {
+	distinctOwners := make(map[types.UID]struct{})
+	for _, pod := range pods {
+		controllerRef := metav1.GetControllerOf(pod)
+		if controllerRef == nil {
+			continue
+		}
+		distinctOwners[controllerRef.UID] = struct{}{}
+	}
+
+	return len(distinctOwners)
+}
+
+func filterByAge(pods []*apiv1.Pod, condition ageCondition, age time.Duration) []*apiv1.Pod {
+	var filtered []*apiv1.Pod
+	for _, pod := range pods {
+		cutoff := pod.GetCreationTimestamp().Time.Add(age)
+		if condition == youngerThan && cutoff.After(time.Now()) {
+			filtered = append(filtered, pod)
+		}
+		if condition == olderThan && cutoff.Before(time.Now()) {
+			filtered = append(filtered, pod)
+		}
+	}
+	return filtered
+}

--- a/cluster-autoscaler/processors/datadog/pods/utils_test.go
+++ b/cluster-autoscaler/processors/datadog/pods/utils_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pods
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestCountDistinctOwnerReferences(t *testing.T) {
+	tests := []struct {
+		name     string
+		pods     []*apiv1.Pod
+		expected int
+	}{
+		{
+			"count all distinct ownerref",
+			[]*apiv1.Pod{testPodWithOwner("a"), testPodWithOwner("b"), testPodWithOwner("c")},
+			3,
+		},
+
+		{
+			"group identical ownerrefs",
+			[]*apiv1.Pod{testPodWithOwner("a"), testPodWithOwner("a"), testPodWithOwner("b")},
+			2,
+		},
+
+		{
+			"don't crash on empty pod list",
+			[]*apiv1.Pod{},
+			0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := countDistinctOwnerReferences(tt.pods)
+			assert.Equal(t, actual, tt.expected)
+		})
+	}
+}
+
+func testPodWithOwner(refname string) *apiv1.Pod {
+	trueish := true
+	return &apiv1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			OwnerReferences: []metav1.OwnerReference{{
+				UID:        types.UID(refname),
+				Name:       refname,
+				Controller: &trueish,
+			}},
+		},
+	}
+}


### PR DESCRIPTION
Based on https://github.com/kubernetes/autoscaler/pull/3964, this PR only implement the mandatory elements to work in a Datadog environment. 

I tried to build the commit to ease any futur rebase of https://github.com/kubernetes/autoscaler. 

- [local] Add podTemplateProcessor option
- [local] Add NodeInfos PodTemplates process implementation
- [local] set PodTemplateProcessor as NodeInfoProcess if enabled
