### PR TITLE
[local] Adopt new TemplateOnlyNodeInfoProvider interface

### DIFF
--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/spf13/pflag"
 
+	"k8s.io/autoscaler/cluster-autoscaler/processors/datadog/nodeinfosprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/datadog/pods"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -321,6 +322,7 @@ func buildAutoscaler() (core.Autoscaler, error) {
 
 	opts.Processors = ca_processors.DefaultProcessors()
 	opts.Processors.PodListProcessor = pods.NewFilteringPodListProcessor()
+	opts.Processors.TemplateNodeInfoProvider = nodeinfosprovider.NewTemplateOnlyNodeInfoProvider()
 
 	nodeInfoComparatorBuilder := nodegroupset.CreateGenericNodeInfoComparator
 	if autoscalingOptions.CloudProviderName == cloudprovider.AzureProviderName {

--- a/cluster-autoscaler/processors/datadog/nodeinfosprovider/template_only_node_info_provider_test.go
+++ b/cluster-autoscaler/processors/datadog/nodeinfosprovider/template_only_node_info_provider_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	apiv1 "k8s.io/api/core/v1"
 	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
@@ -44,16 +45,13 @@ func TestTemplateOnlyNodeInfoProviderProcess(t *testing.T) {
 	provider1.AddNodeGroup("ng1", 1, 10, 1)
 	provider1.AddNodeGroup("ng2", 2, 20, 2)
 
+	ctx := &context.AutoscalingContext{
+		PredicateChecker: predicateChecker,
+		CloudProvider:    provider1,
+	}
+
 	processor := NewTemplateOnlyNodeInfoProvider()
-	res, err := processor.GetNodeInfosForGroups(
-		nil,
-		nil,
-		provider1,
-		nil,
-		nil,
-		predicateChecker,
-		nil,
-	)
+	res, err := processor.Process(ctx, nil, nil, nil)
 
 	// nodegroups providing templates
 	assert.NoError(t, err)


### PR DESCRIPTION
No functional changes: this only makes TemplateOnlyNodeInfoProvider conformant to the new TemplateNodeInfoProvider interface. This allows for a cleaner integration with the core autoscaler.

Also: SanitizeTemplateNode and SanitizeNodeInfo are now exported (from core/utils) function, no need to keep a local copy anymore.

nb: the patch that hooked the previous implementation to core+processor is already dropped (to keep a clean history and not having to cope with that obsolete and intrusive patch during future rebases to upstream/master).
