### PR TITLE
[local] resync schedulable filters with upstream

### DIFF
--- a/cluster-autoscaler/processors/datadog/pods/filter_schedulable_test.go
+++ b/cluster-autoscaler/processors/datadog/pods/filter_schedulable_test.go
@@ -113,7 +113,7 @@ func TestFilterOutSchedulableByPacking(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
-			filterOutSchedulablePodListProcessor := NewFilterOutSchedulable()
+			filterOutSchedulablePodListProcessor := NewFilterOutSchedulablePodListProcessor()
 
 			err = clusterSnapshot.Fork()
 			assert.NoError(t, err)
@@ -258,7 +258,7 @@ func BenchmarkFilterOutSchedulableByPacking(b *testing.B) {
 				b.ResetTimer()
 
 				for i := 0; i < b.N; i++ {
-					filterOutSchedulablePodListProcessor := NewFilterOutSchedulable()
+					filterOutSchedulablePodListProcessor := NewFilterOutSchedulablePodListProcessor()
 					if stillPending, err := filterOutSchedulablePodListProcessor.filterOutSchedulableByPacking(pendingPods, clusterSnapshot, predicateChecker); err != nil {
 						assert.NoError(b, err)
 					} else if len(stillPending) < tc.pendingPods {

--- a/cluster-autoscaler/processors/datadog/pods/processor.go
+++ b/cluster-autoscaler/processors/datadog/pods/processor.go
@@ -41,7 +41,7 @@ func NewFilteringPodListProcessor() *filteringPodListProcessor {
 		},
 		filters: []proc.PodListProcessor{
 			NewFilterOutLongPending(),
-			NewFilterOutSchedulable(),
+			NewFilterOutSchedulablePodListProcessor(),
 		},
 	}
 }


### PR DESCRIPTION
Resync with upstream's `core/filter_out_schedulable.go` recent changes: no new local features, just changes to reduce drift. After this diff, and reflecting a change from upstream, having pending pods around won't block downscales.

That custom processor now only differs (from upstream filter_out_schedulable.go) on two ways:
* It avoid `NodeReady` nodes blocking upscales where taint based eviction isn't there (eg. older kubernetes versions)
* It accounts for filtered out long pending pods (which doesn't matter much now that pending pods don't inhibit downscales, so this chunk might go away on future revisions)

Here's what remains different (`diff -u  core/filter_out_schedulable.go ./processors/datadog/pods/filter_schedulable.go`):
https://gist.github.com/bpineau/3d90cd4d8d0e4239c7660024982161e1
