### PR TITLE
vpa/admission-controller: add UpdateMode 'Trigger'

### DIFF
--- a/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
@@ -394,6 +394,7 @@ spec:
                     - Initial
                     - Recreate
                     - Auto
+                    - Trigger
                     type: string
                 type: object
             required:

--- a/vertical-pod-autoscaler/enhancements/xxxx-update-mode-trigger/README.md
+++ b/vertical-pod-autoscaler/enhancements/xxxx-update-mode-trigger/README.md
@@ -41,9 +41,9 @@ changes only when they deploy their application.
 
 The proposal is to extend the existing admission controller.
 
-A new `vpaTrigger` annotation and the associated `UpdateMode` `Trigger` will be created. When
-an admitted resource is handled by the admission controller, recommendations will be applied only
-if the `vpaTrigger` annotation is present and equal to `true`. 
+A new `vpaTrigger` annotation on the controller (deployment/sts) and the associated `UpdateMode` `Trigger`
+in the VPA object will be created. When  an admitted resource is handled by the admission controller,
+recommendations will be applied only  if the `vpaTrigger` annotation is present and equal to `true`. 
 
 The admission controller will now also watch and mutate creation and updates of
 `Deployment` and `StatefulSet`. It will do so by changing the `PodTemplateSpec` in the

--- a/vertical-pod-autoscaler/enhancements/xxxx-update-mode-trigger/README.md
+++ b/vertical-pod-autoscaler/enhancements/xxxx-update-mode-trigger/README.md
@@ -1,0 +1,74 @@
+# KEP-XXXX: Patch Well Known Controllers instead of Pods
+
+<!-- toc -->
+- [Summary](#summary)
+- [Motivation](#motivation)
+    - [Goals](#goals)
+    - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+- [Design Details](#design-details)
+    - [Test Plan](#test-plan)
+- [Implementation History](#implementation-history)
+- [Alternatives](#alternatives)
+    - [Update the eviction API](#update-the-eviction-api)
+<!-- /toc -->
+
+## Summary
+
+The default behaviour of VPA Admission controller is to patch Pods when `UpdateModde`
+is different from `Off`. This works fine if we accept vertical scaling outside standard deployments.
+
+For a wide range of application we cannot guarantee that such changes will not
+result in degraded performances, or worse, break the application. Because of that
+users might want to do that only as part of their regular deployment procedure. This
+makes even more sense when those deployments are done to multiple kubernetes clusters
+with safeguards between them.
+
+## Motivation
+
+The motivation behind the change is to give VPA users a way to apply resource
+changes only when they deploy their application.
+
+### Goals
+
+- Main: allow users to apply resource recommendation on demand (mostly during application deployment)
+
+### Non-Goals
+
+- Get rid of other update modes
+
+## Proposal
+
+The proposal is to extend the existing admission controller.
+
+A new `vpaTrigger` annotation and the associated `UpdateMode` `Trigger` will be created. When
+an admitted resource is handled by the admission controller, recommendations will be applied only
+if the `vpaTrigger` annotation is present and equal to `true`. 
+
+The admission controller will now also watch and mutate creation and updates of
+`Deployment` and `StatefulSet`. It will do so by changing the `PodTemplateSpec` in the
+same way it updates the `PodSpec` of a `Pod`.
+
+## Design Details
+
+- If `UpdateMode` is set to `Trigger` and the `vpaTrigger` annotation is equal to `true`:
+the recommendations are applied and the `vpaTrigger` annotation is set to `triggered`.
+- Otherwise, nothing happens.
+
+The intent is to let users trigger a recommendation using:
+`kubectl annotate deployment/hamster-deployment vpaTrigger=true`
+
+The will also be able to simply set `vpaTrigger=true` in their charts to
+trigger a new recommendation at each `apply` of the chart.
+
+To make the code easier to rebase, the new resource handler will re-use most
+of the pod resource handlers. If this ever get merged part of the code will be
+re-worked to deal with `PodSpec` instead of `Pod`
+
+### Test Plan
+
+Add unit tests that cover the new code paths.
+
+## Implementation History
+
+- 2022-11-28: initial version

--- a/vertical-pod-autoscaler/examples/hamster-workload.yaml
+++ b/vertical-pod-autoscaler/examples/hamster-workload.yaml
@@ -1,0 +1,122 @@
+# This config creates a deployment with two pods, each requesting 100 millicores
+# and trying to utilize slightly above 500 millicores (repeatedly using CPU for
+# 0.5s and sleeping 0.5s).
+# It also creates a corresponding Vertical Pod Autoscaler that adjusts the
+# requests.
+---
+apiVersion: "autoscaling.k8s.io/v1"
+kind: VerticalPodAutoscaler
+metadata:
+  name: hamster-deployment-vpa
+spec:
+  # recommenders field can be unset when using the default recommender.
+  # When using an alternative recommender, the alternative recommender's name
+  # can be specified as the following in a list.
+  # recommenders: 
+  #   - name: 'alternative'
+  targetRef:
+    apiVersion: "apps/v1"
+    kind: Deployment
+    name: hamster-deployment
+  updatePolicy:
+    updateMode: Trigger
+  resourcePolicy:
+    containerPolicies:
+      - containerName: '*'
+        minAllowed:
+          cpu: 10m
+          memory: 50Mi
+        maxAllowed:
+          cpu: 600m
+          memory: 500Mi
+        controlledResources: ["cpu", "memory"]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hamster-deployment
+  annotations:
+    vpaTrigger: "true"
+spec:
+  selector:
+    matchLabels:
+      app: hamster-deployment
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: hamster-deployment
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534 # nobody
+      containers:
+        - name: hamster
+          image: k8s.gcr.io/ubuntu-slim:0.1
+          resources:
+            requests:
+              cpu: 10m
+              memory: 50Mi
+          command: ["/bin/sh"]
+          args:
+            - "-c"
+            - "while true; do timeout 0.5s yes >/dev/null; sleep 0.5s; done"
+---
+apiVersion: "autoscaling.k8s.io/v1"
+kind: VerticalPodAutoscaler
+metadata:
+  name: hamster-statefulset-vpa
+spec:
+  # recommenders field can be unset when using the default recommender.
+  # When using an alternative recommender, the alternative recommender's name
+  # can be specified as the following in a list.
+  # recommenders:
+  #   - name: 'alternative'
+  targetRef:
+    apiVersion: "apps/v1"
+    kind: StatefulSet
+    name: hamster-statefulset
+  updatePolicy:
+    updateMode: Trigger
+  resourcePolicy:
+    containerPolicies:
+      - containerName: '*'
+        minAllowed:
+          cpu: 10m
+          memory: 50Mi
+        maxAllowed:
+          cpu: 600m
+          memory: 500Mi
+        controlledResources: ["cpu", "memory"]
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: hamster-statefulset
+  annotations:
+    vpaTrigger: "true"
+spec:
+  selector:
+    matchLabels:
+      app: hamster-statefulset
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: hamster-statefulset
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534 # nobody
+      containers:
+        - name: hamster
+          image: k8s.gcr.io/ubuntu-slim:0.1
+          resources:
+            requests:
+              cpu: 10m
+              memory: 50Mi
+          command: ["/bin/sh"]
+          args:
+            - "-c"
+            - "while true; do timeout 0.5s yes >/dev/null; sleep 0.5s; done"
+  serviceName: hamster-statefulset

--- a/vertical-pod-autoscaler/hack/generate-crd-yaml.sh
+++ b/vertical-pod-autoscaler/hack/generate-crd-yaml.sh
@@ -32,7 +32,7 @@ trap cleanup EXIT
 if [[ -z $(which controller-gen) ]]; then
     (
         cd $WORKSPACE
-	      go install sigs.k8s.io/controller-tools/cmd/controller-gen@0.9.2
+	      go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.2
     )
     CONTROLLER_GEN=${GOBIN:-$(go env GOPATH)/bin}/controller-gen
 else

--- a/vertical-pod-autoscaler/pkg/admission-controller/README.md
+++ b/vertical-pod-autoscaler/pkg/admission-controller/README.md
@@ -16,7 +16,7 @@ one and use current recommendation to set resource requests in the pod.
 
 For each deployment or statefulset creation or update, it will get a request from the
 apiserver and either decide there's no matching VPA configuration or find the corresponding
-one and if `UpdateMode` is set to `Annotation` and the `vpaTrigger: true` annotion is set, it
+one and if `UpdateMode` is set to `Annotation` and the `vpaTrigger: true` annotation is set, it
 will use current recommendation to set resource requests in the pod template spec.
 
 ## Running

--- a/vertical-pod-autoscaler/pkg/admission-controller/README.md
+++ b/vertical-pod-autoscaler/pkg/admission-controller/README.md
@@ -7,10 +7,17 @@
 ## Intro
 
 This is a binary that registers itself as a Mutating Admission Webhook
-and because of that is on the path of creating all pods.
+and because of that is on the path of creating all pods and
+creating or updating all deployments and statefulsets.
+
 For each pod creation, it will get a request from the apiserver and it will
 either decide there's no matching VPA configuration or find the corresponding
 one and use current recommendation to set resource requests in the pod.
+
+For each deployment or statefulset creation or update, it will get a request from the
+apiserver and either decide there's no matching VPA configuration or find the corresponding
+one and if `UpdateMode` is set to `Annotation` and the `vpaTrigger: true` annotion is set, it
+will use current recommendation to set resource requests in the pod template spec.
 
 ## Running
 
@@ -29,7 +36,7 @@ up the changes: ```sudo systemctl restart kubelet.service```
    `kubectl create -f ../deploy/admission-controller-deployment.yaml`.
    The first thing this will do is it will register itself with the apiserver as
    Webhook Admission Controller and start changing resource requirements
-   for pods on their creation & updates.
+   for pods, deployments and statefulsets on their creation & updates.
 1. You can specify a path for it to register as a part of the installation process
    by setting `--register-by-url=true` and passing `--webhook-address` and `--webhook-port`.
 

--- a/vertical-pod-autoscaler/pkg/admission-controller/config.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/config.go
@@ -89,6 +89,22 @@ func selfRegistration(clientset *kubernetes.Clientset, caCert []byte, namespace,
 							Resources:   []string{"verticalpodautoscalers"},
 						},
 					},
+					{
+						Operations: []admissionregistration.OperationType{admissionregistration.Create, admissionregistration.Update},
+						Rule: admissionregistration.Rule{
+							APIGroups:   []string{"apps"},
+							APIVersions: []string{"v1"},
+							Resources:   []string{"deployments"},
+						},
+					},
+					{
+						Operations: []admissionregistration.OperationType{admissionregistration.Create, admissionregistration.Update},
+						Rule: admissionregistration.Rule{
+							APIGroups:   []string{"apps"},
+							APIVersions: []string{"v1"},
+							Resources:   []string{"statefulsets"},
+						},
+					},
 				},
 				FailurePolicy:  &failurePolicy,
 				ClientConfig:   RegisterClientConfig,

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/deployment/handller_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/deployment/handller_test.go
@@ -1,0 +1,206 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployment
+
+import (
+	"fmt"
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	apiv1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/stretchr/testify/assert"
+
+	resource_admission "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch"
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
+)
+
+type fakePodPreProcessor struct {
+	err error
+}
+
+func (fpp *fakePodPreProcessor) Process(pod apiv1.Pod) (apiv1.Pod, error) {
+	return pod, fpp.err
+}
+
+type fakeVpaMatcher struct {
+	vpa *vpa_types.VerticalPodAutoscaler
+}
+
+func (m *fakeVpaMatcher) GetMatchingVPA(_ *apiv1.Pod) *vpa_types.VerticalPodAutoscaler {
+	return m.vpa
+}
+
+type fakePatchCalculator struct {
+	patches []resource_admission.PatchRecord
+	err     error
+}
+
+func (c *fakePatchCalculator) CalculatePatches(_ *apiv1.Pod, _ *vpa_types.VerticalPodAutoscaler) (
+	[]resource_admission.PatchRecord, error) {
+	return c.patches, c.err
+}
+
+func TestGetPatches(t *testing.T) {
+	testVpa := test.VerticalPodAutoscaler().WithUpdateMode(vpa_types.UpdateModeTrigger).WithName("name").WithContainer("testy-container").Get()
+	testPatchRecord := resource_admission.PatchRecord{
+		Op:    "add",
+		Path:  "some/path",
+		Value: "much",
+	}
+	testPatchRecord2 := resource_admission.PatchRecord{
+		Op:    "add",
+		Path:  "other/path",
+		Value: "not so much",
+	}
+	tests := []struct {
+		name                 string
+		deploymentJson       []byte
+		namespace            string
+		vpa                  *vpa_types.VerticalPodAutoscaler
+		podPreProcessorError error
+		calculators          []patch.Calculator
+		expectPatches        []resource_admission.PatchRecord
+		expectError          error
+	}{
+		{
+			name:                 "invalid JSON",
+			deploymentJson:       []byte("{"),
+			namespace:            "default",
+			vpa:                  testVpa,
+			podPreProcessorError: nil,
+			expectError:          fmt.Errorf("unexpected end of JSON input"),
+		},
+		{
+			name:                 "invalid deployment",
+			deploymentJson:       []byte("{}"),
+			namespace:            "default",
+			vpa:                  testVpa,
+			podPreProcessorError: fmt.Errorf("bad deployment"),
+			expectError:          fmt.Errorf("bad deployment"),
+		},
+		{
+			name:                 "no vpa found",
+			deploymentJson:       []byte("{}"),
+			namespace:            "test",
+			vpa:                  nil,
+			podPreProcessorError: nil,
+			expectError:          nil,
+			expectPatches:        []resource_admission.PatchRecord{},
+		},
+		{
+			name:           "calculator returns error",
+			deploymentJson: []byte("{}"),
+			namespace:      "test",
+			vpa:            testVpa,
+			calculators: []patch.Calculator{&fakePatchCalculator{
+				[]resource_admission.PatchRecord{}, fmt.Errorf("Can't calculate this"),
+			}},
+			podPreProcessorError: nil,
+			expectError:          fmt.Errorf("Can't calculate this"),
+			expectPatches:        []resource_admission.PatchRecord{},
+		},
+		{
+			name:           "second calculator returns error",
+			deploymentJson: []byte("{}"),
+			namespace:      "test",
+			vpa:            testVpa,
+			calculators: []patch.Calculator{
+				&fakePatchCalculator{[]resource_admission.PatchRecord{
+					testPatchRecord,
+				}, nil},
+				&fakePatchCalculator{
+					[]resource_admission.PatchRecord{}, fmt.Errorf("Can't calculate this"),
+				}},
+			podPreProcessorError: nil,
+			expectError:          fmt.Errorf("Can't calculate this"),
+			expectPatches:        []resource_admission.PatchRecord{},
+		},
+		{
+			name:           "patches returned correctly",
+			deploymentJson: []byte("{}"),
+			namespace:      "test",
+			vpa:            testVpa,
+			calculators: []patch.Calculator{
+				&fakePatchCalculator{[]resource_admission.PatchRecord{
+					testPatchRecord,
+					testPatchRecord2,
+				}, nil}},
+			podPreProcessorError: nil,
+			expectError:          nil,
+			expectPatches: []resource_admission.PatchRecord{
+				patch.GetAddEmptyAnnotationsPatch(),
+				testPatchRecord,
+				testPatchRecord2,
+			},
+		},
+		{
+			name:           "patches returned correctly for multiple calculators",
+			deploymentJson: []byte("{}"),
+			namespace:      "test",
+			vpa:            testVpa,
+			calculators: []patch.Calculator{
+				&fakePatchCalculator{[]resource_admission.PatchRecord{
+					testPatchRecord,
+				}, nil},
+				&fakePatchCalculator{[]resource_admission.PatchRecord{
+					testPatchRecord2,
+				}, nil}},
+			podPreProcessorError: nil,
+			expectError:          nil,
+			expectPatches: []resource_admission.PatchRecord{
+				patch.GetAddEmptyAnnotationsPatch(),
+				testPatchRecord,
+				testPatchRecord2,
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("test case: %s", tc.name), func(t *testing.T) {
+			fppp := &fakePodPreProcessor{tc.podPreProcessorError}
+			fvm := &fakeVpaMatcher{vpa: tc.vpa}
+			h := NewResourceHandler(fppp, fvm, tc.calculators)
+			patches, err := h.GetPatches(&admissionv1.AdmissionRequest{
+				Resource: v1.GroupVersionResource{
+					Version: "v1",
+				},
+				Namespace: tc.namespace,
+				Object: runtime.RawExtension{
+					Raw: tc.deploymentJson,
+				},
+			})
+			if tc.expectError == nil {
+				assert.NoError(t, err)
+			} else {
+				if assert.Error(t, err) {
+					assert.Equal(t, tc.expectError.Error(), err.Error())
+				}
+			}
+			if assert.Equal(t, len(tc.expectPatches), len(patches), fmt.Sprintf("got %+v, want %+v", patches, tc.expectPatches)) {
+				for i, gotPatch := range patches {
+					if !patch.EqPatch(gotPatch, tc.expectPatches[i]) {
+						t.Errorf("Expected patch at position %d to be %+v, got %+v", i, tc.expectPatches[i], gotPatch)
+					}
+				}
+			}
+		})
+	}
+}

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/update_trigger.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/update_trigger.go
@@ -17,6 +17,8 @@ limitations under the License.
 package patch
 
 import (
+	"time"
+
 	core "k8s.io/api/core/v1"
 
 	resource_admission "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource"
@@ -26,11 +28,13 @@ import (
 
 type updateTrigger struct{}
 
+var now = time.Now
+
 func (*updateTrigger) CalculatePatches(pod *core.Pod, _ *vpa_types.VerticalPodAutoscaler) ([]resource_admission.PatchRecord, error) {
 	patches := []resource_admission.PatchRecord{}
 
 	if annotations.HasVpaTrigger(&pod.ObjectMeta) {
-		patches = append(patches, GetAddAnnotationPatch(annotations.VpaTriggerLabel, annotations.VpaTriggerTriggered))
+		patches = append(patches, GetAddAnnotationPatch(annotations.VpaTriggerLabel, annotations.GetVpaTriggeredValue(now())))
 	}
 
 	return patches, nil

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/update_trigger.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/update_trigger.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch
+
+import (
+	core "k8s.io/api/core/v1"
+
+	resource_admission "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource"
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/annotations"
+)
+
+type updateTrigger struct{}
+
+func (*updateTrigger) CalculatePatches(pod *core.Pod, _ *vpa_types.VerticalPodAutoscaler) ([]resource_admission.PatchRecord, error) {
+	patches := []resource_admission.PatchRecord{}
+
+	if annotations.HasVpaTrigger(&pod.ObjectMeta) {
+		patches = append(patches, GetAddAnnotationPatch(annotations.VpaTriggerLabel, annotations.VpaTriggerTriggered))
+	}
+
+	return patches, nil
+}
+
+// NewUpdateTriggerCalculator returns calculator for
+// the trigger annotation patches.
+func NewUpdateTriggerCalculator() Calculator {
+	return &updateTrigger{}
+}

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/update_trigger_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/update_trigger_test.go
@@ -18,6 +18,7 @@ package patch
 
 import (
 	"testing"
+	"time"
 
 	core "k8s.io/api/core/v1"
 
@@ -34,6 +35,11 @@ func addVpaUpdateTriggerPatch(value string) *resource_admission.PatchRecord {
 }
 
 func TestCalculatePatches_UpdateTrigger(t *testing.T) {
+	now = func() time.Time { return time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC) }
+	defer func() {
+		now = time.Now
+	}()
+
 	tests := []struct {
 		name          string
 		pod           *core.Pod
@@ -47,11 +53,11 @@ func TestCalculatePatches_UpdateTrigger(t *testing.T) {
 		{
 			name:          "update vpa update trigger annotation",
 			pod:           test.Pod().WithAnnotations(map[string]string{annotations.VpaTriggerLabel: annotations.VpaTriggerEnabled}).Get(),
-			expectedPatch: addVpaUpdateTriggerPatch(annotations.VpaTriggerTriggered),
+			expectedPatch: addVpaUpdateTriggerPatch(annotations.GetVpaTriggeredValue(now())),
 		},
 		{
 			name:          "doesn't vpa update trigger annotation if already triggered",
-			pod:           test.Pod().WithAnnotations(map[string]string{annotations.VpaTriggerLabel: annotations.VpaTriggerTriggered}).Get(),
+			pod:           test.Pod().WithAnnotations(map[string]string{annotations.VpaTriggerLabel: annotations.GetVpaTriggeredValue(now())}).Get(),
 			expectedPatch: nil,
 		},
 	}

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/update_trigger_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/update_trigger_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch
+
+import (
+	"testing"
+
+	core "k8s.io/api/core/v1"
+
+	resource_admission "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/annotations"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func addVpaUpdateTriggerPatch(value string) *resource_admission.PatchRecord {
+	patch := GetAddAnnotationPatch(annotations.VpaTriggerLabel, value)
+	return &patch
+}
+
+func TestCalculatePatches_UpdateTrigger(t *testing.T) {
+	tests := []struct {
+		name          string
+		pod           *core.Pod
+		expectedPatch *resource_admission.PatchRecord
+	}{
+		{
+			name:          "doesn't update pod without trigger annotation",
+			pod:           test.Pod().Get(),
+			expectedPatch: nil,
+		},
+		{
+			name:          "update vpa update trigger annotation",
+			pod:           test.Pod().WithAnnotations(map[string]string{annotations.VpaTriggerLabel: annotations.VpaTriggerEnabled}).Get(),
+			expectedPatch: addVpaUpdateTriggerPatch(annotations.VpaTriggerTriggered),
+		},
+		{
+			name:          "doesn't vpa update trigger annotation if already triggered",
+			pod:           test.Pod().WithAnnotations(map[string]string{annotations.VpaTriggerLabel: annotations.VpaTriggerTriggered}).Get(),
+			expectedPatch: nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := NewUpdateTriggerCalculator()
+			patches, err := c.CalculatePatches(tc.pod, nil)
+			assert.NoError(t, err)
+			if tc.expectedPatch != nil {
+				if assert.Len(t, patches, 1, "Unexpected number of patches.") {
+					AssertEqPatch(t, *tc.expectedPatch, patches[0])
+				}
+			} else {
+				assert.Empty(t, patches)
+			}
+		})
+	}
+}

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/statefulset/handler.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/statefulset/handler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,91 +14,65 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package pod
+package statefulset
 
 import (
 	"encoding/json"
 	"fmt"
 
 	admissionv1 "k8s.io/api/admission/v1"
-	v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
-
 	resource_admission "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource"
+
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/workloads"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/admission"
+	"k8s.io/klog/v2"
 )
 
-// resourceHandler builds patches for Pods.
+// resourceHandler builds patches for StatefulSets.
 type resourceHandler struct {
-	preProcessor     PreProcessor
-	vpaMatcher       vpa.Matcher
-	patchCalculators []patch.Calculator
+	workloads.WorkloadResourceHandler
 }
 
 // NewResourceHandler creates new instance of resourceHandler.
-func NewResourceHandler(preProcessor PreProcessor, vpaMatcher vpa.Matcher, patchCalculators []patch.Calculator) resource_admission.Handler {
+func NewResourceHandler(preProcessor pod.PreProcessor, vpaMatcher vpa.Matcher, patchCalculators []patch.Calculator) resource_admission.Handler {
 	return &resourceHandler{
-		preProcessor:     preProcessor,
-		vpaMatcher:       vpaMatcher,
-		patchCalculators: patchCalculators,
+		*workloads.NewResourceHandler(preProcessor, vpaMatcher, patchCalculators),
 	}
 }
 
 // AdmissionResource returns resource type this handler accepts.
 func (h *resourceHandler) AdmissionResource() admission.AdmissionResource {
-	return admission.Pod
+	return admission.StatefulSet
 }
 
 // GroupResource returns Group and Resource type this handler accepts.
 func (h *resourceHandler) GroupResource() metav1.GroupResource {
-	return metav1.GroupResource{Group: "", Resource: "pods"}
+	return metav1.GroupResource{Group: "apps", Resource: "statefulsets"}
 }
 
 // DisallowIncorrectObjects decides whether incorrect objects (eg. unparsable, not passing validations) should be disallowed by Admission Server.
 func (h *resourceHandler) DisallowIncorrectObjects() bool {
-	// Incorrect Pods are validated by API Server.
+	// Incorrect StatefulSets are validated by API Server.
 	return false
 }
 
-// GetPatches builds patches for Pod in given admission request.
+// GetPatches builds patches for StatefulSets in given admission request.
 func (h *resourceHandler) GetPatches(ar *admissionv1.AdmissionRequest) ([]resource_admission.PatchRecord, error) {
 	if ar.Resource.Version != "v1" {
-		return nil, fmt.Errorf("only v1 Pods are supported")
+		return nil, fmt.Errorf("only v1 statefulsets are supported")
 	}
 	raw, namespace := ar.Object.Raw, ar.Namespace
-	pod := v1.Pod{}
-	if err := json.Unmarshal(raw, &pod); err != nil {
-		return nil, err
-	}
-	if len(pod.Name) == 0 {
-		pod.Name = pod.GenerateName + "%"
-		pod.Namespace = namespace
-	}
-	klog.V(4).Infof("Admitting pod %v", pod.ObjectMeta)
-	controllingVpa := h.vpaMatcher.GetMatchingVPA(&pod)
-	if controllingVpa == nil {
-		klog.V(4).Infof("No matching VPA found for pod %s/%s", pod.Namespace, pod.Name)
-		return []resource_admission.PatchRecord{}, nil
-	}
-	pod, err := h.preProcessor.Process(pod)
-	if err != nil {
+	sts := v1.StatefulSet{}
+	if err := json.Unmarshal(raw, &sts); err != nil {
 		return nil, err
 	}
 
-	patches := []resource_admission.PatchRecord{}
-	if pod.Annotations == nil {
-		patches = append(patches, patch.GetAddEmptyAnnotationsPatch())
-	}
-	for _, c := range h.patchCalculators {
-		partialPatches, err := c.CalculatePatches(&pod, controllingVpa)
-		if err != nil {
-			return []resource_admission.PatchRecord{}, err
-		}
-		patches = append(patches, partialPatches...)
-	}
+	klog.V(4).Infof("Admitting statefulset %v", sts.ObjectMeta)
 
-	return patches, nil
+	return h.GetPatchesForWorkload(namespace, &sts.ObjectMeta, &sts.Spec.Template)
 }

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler.go
@@ -25,10 +25,11 @@ import (
 	apires "k8s.io/apimachinery/pkg/api/resource"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource"
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/admission"
-	"k8s.io/klog/v2"
 )
 
 var (
@@ -37,6 +38,7 @@ var (
 		vpa_types.UpdateModeInitial:  struct{}{},
 		vpa_types.UpdateModeRecreate: struct{}{},
 		vpa_types.UpdateModeAuto:     struct{}{},
+		vpa_types.UpdateModeTrigger:  struct{}{},
 	}
 
 	possibleScalingModes = map[vpa_types.ContainerScalingMode]interface{}{

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/matcher.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/matcher.go
@@ -19,11 +19,13 @@ package vpa
 import (
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/klog/v2"
+
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	vpa_lister "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/target"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/annotations"
 	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
-	"k8s.io/klog/v2"
 )
 
 // Matcher is capable of returning a single matching VPA object
@@ -52,8 +54,16 @@ func (m *matcher) GetMatchingVPA(pod *core.Pod) *vpa_types.VerticalPodAutoscaler
 	}
 	onConfigs := make([]*vpa_api_util.VpaWithSelector, 0)
 	for _, vpaConfig := range configs {
-		if vpa_api_util.GetUpdateMode(vpaConfig) == vpa_types.UpdateModeOff {
+		updateMode := vpa_api_util.GetUpdateMode(vpaConfig)
+		if updateMode == vpa_types.UpdateModeOff {
 			continue
+		}
+		if updateMode == vpa_types.UpdateModeTrigger {
+			if !annotations.HasVpaTrigger(&pod.ObjectMeta) {
+				klog.V(3).Infof("skipping VPA object %v with UpdateMode %s because %s does not have the `%s:%s` annotation.",
+					vpaConfig.Name, updateMode, pod.Name, annotations.VpaTriggerLabel, annotations.VpaTriggerEnabled)
+				continue
+			}
 		}
 		selector, err := m.selectorFetcher.Fetch(vpaConfig)
 		if err != nil {

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/workloads/utils.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/workloads/utils.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workloads
+
+import (
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+
+	resource_admission "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/annotations"
+)
+
+// WorkloadResourceHandler builds patches for Workloads.
+type WorkloadResourceHandler struct {
+	preProcessor     pod.PreProcessor
+	vpaMatcher       vpa.Matcher
+	patchCalculators []patch.Calculator
+}
+
+// NewResourceHandler creates new instance of resourceHandler.
+func NewResourceHandler(preProcessor pod.PreProcessor, vpaMatcher vpa.Matcher, patchCalculators []patch.Calculator) *WorkloadResourceHandler {
+	return &WorkloadResourceHandler{
+		preProcessor:     preProcessor,
+		vpaMatcher:       vpaMatcher,
+		patchCalculators: patchCalculators,
+	}
+}
+
+// GetPatchesForWorkload builds patches for Pod in given admission request.
+func (h *WorkloadResourceHandler) GetPatchesForWorkload(namespace string, objectMeta *metav1.ObjectMeta, podTemplateSpec *v1.PodTemplateSpec) ([]resource_admission.PatchRecord, error) {
+	if len(objectMeta.Name) == 0 {
+		objectMeta.Name = objectMeta.GenerateName + "%"
+		objectMeta.Namespace = namespace
+	}
+
+	// We create a `Pod` to be able to re-use the pod code.
+	pod := PodFromPodTemplateSpec(objectMeta, podTemplateSpec)
+	klog.V(4).Infof("Generating pod %s/%s", pod.Namespace, pod.Name)
+	controllingVpa := h.vpaMatcher.GetMatchingVPA(&pod)
+	if controllingVpa == nil {
+		klog.V(4).Infof("No matching VPA found for %s/%s", objectMeta.Namespace, objectMeta.Name)
+		return []resource_admission.PatchRecord{}, nil
+	}
+	pod, err := h.preProcessor.Process(pod)
+	if err != nil {
+		return nil, err
+	}
+
+	patches := []resource_admission.PatchRecord{}
+	if objectMeta.Annotations == nil {
+		patches = append(patches, patch.GetAddEmptyAnnotationsPatch())
+	}
+	for _, c := range h.patchCalculators {
+		partialPatches, err := c.CalculatePatches(&pod, controllingVpa)
+		if err != nil {
+			return []resource_admission.PatchRecord{}, err
+		}
+		patches = append(patches, partialPatches...)
+	}
+
+	return FixupPodPatchesForWorkload(patches), nil
+}
+
+// FixupPodPatchesForWorkload takes patches for a pod and adapt them to be applied to a workload.
+func FixupPodPatchesForWorkload(patches []resource_admission.PatchRecord) []resource_admission.PatchRecord {
+	for i, patch := range patches {
+		// If it's a patch to spec, add the path to the PodSpec
+		if strings.HasPrefix(patch.Path, "/spec/") {
+			patches[i].Path = "/spec/template" + patch.Path
+		}
+	}
+	return patches
+}
+
+// PodFromPodTemplateSpec creates a fake Pod object from a PodTemplateSpec. This is used by the workload
+// admission controllers tu re-use as much code as we can without modifying it, it makes rebases easier.
+// If we ever want to upstream this code we should make the pod code more generic.
+func PodFromPodTemplateSpec(objectMeta *metav1.ObjectMeta, podTemplateSpec *v1.PodTemplateSpec) v1.Pod {
+	pod := v1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		// This is important to get the same labels as the pod (which need to match the selector)
+		ObjectMeta: podTemplateSpec.ObjectMeta,
+		Spec:       podTemplateSpec.Spec,
+		Status:     v1.PodStatus{},
+	}
+	// We also need to propagate the trigger annotation that was likely set on the parent.
+	if annotations.HasVpaTrigger(objectMeta) {
+		pod.Annotations[annotations.VpaTriggerLabel] = annotations.VpaTriggerEnabled
+	}
+	if pod.Name == "" {
+		pod.Name = objectMeta.Name + "%"
+	}
+	if pod.Namespace == "" {
+		pod.Namespace = objectMeta.Namespace
+	}
+	return pod
+}

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/workloads/utils_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/workloads/utils_test.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workloads
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	resource_admission "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch"
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
+)
+
+type fakePodPreProcessor struct {
+	err error
+}
+
+func (fpp *fakePodPreProcessor) Process(pod apiv1.Pod) (apiv1.Pod, error) {
+	return pod, fpp.err
+}
+
+type fakeVpaMatcher struct {
+	vpa *vpa_types.VerticalPodAutoscaler
+}
+
+func (m *fakeVpaMatcher) GetMatchingVPA(_ *apiv1.Pod) *vpa_types.VerticalPodAutoscaler {
+	return m.vpa
+}
+
+type fakePatchCalculator struct {
+	patches []resource_admission.PatchRecord
+	err     error
+}
+
+func (c *fakePatchCalculator) CalculatePatches(_ *apiv1.Pod, _ *vpa_types.VerticalPodAutoscaler) (
+	[]resource_admission.PatchRecord, error) {
+	return c.patches, c.err
+}
+
+func TestGetPatches(t *testing.T) {
+	testVpa := test.VerticalPodAutoscaler().WithUpdateMode(vpa_types.UpdateModeTrigger).WithName("name").WithContainer("testy-container").Get()
+	testPatchRecord := resource_admission.PatchRecord{
+		Op:    "add",
+		Path:  "some/path",
+		Value: "much",
+	}
+	testPatchRecord2 := resource_admission.PatchRecord{
+		Op:    "add",
+		Path:  "other/path",
+		Value: "not so much",
+	}
+	testPatchRecordSpec := resource_admission.PatchRecord{
+		Op:    "replace",
+		Path:  "/spec/containers/1/resources/requests",
+		Value: "1",
+	}
+	tests := []struct {
+		name                 string
+		namespace            string
+		vpa                  *vpa_types.VerticalPodAutoscaler
+		podPreProcessorError error
+		calculators          []patch.Calculator
+		expectPatches        []resource_admission.PatchRecord
+		expectError          error
+	}{
+		{
+			name:                 "no vpa found",
+			namespace:            "test",
+			vpa:                  nil,
+			podPreProcessorError: nil,
+			expectError:          nil,
+			expectPatches:        []resource_admission.PatchRecord{},
+		},
+		{
+			name: "calculator returns error",
+
+			namespace: "test",
+			vpa:       testVpa,
+			calculators: []patch.Calculator{&fakePatchCalculator{
+				[]resource_admission.PatchRecord{}, fmt.Errorf("Can't calculate this"),
+			}},
+			podPreProcessorError: nil,
+			expectError:          fmt.Errorf("Can't calculate this"),
+			expectPatches:        []resource_admission.PatchRecord{},
+		},
+		{
+			name: "second calculator returns error",
+
+			namespace: "test",
+			vpa:       testVpa,
+			calculators: []patch.Calculator{
+				&fakePatchCalculator{[]resource_admission.PatchRecord{
+					testPatchRecord,
+				}, nil},
+				&fakePatchCalculator{
+					[]resource_admission.PatchRecord{}, fmt.Errorf("Can't calculate this"),
+				}},
+			podPreProcessorError: nil,
+			expectError:          fmt.Errorf("Can't calculate this"),
+			expectPatches:        []resource_admission.PatchRecord{},
+		},
+		{
+			name: "patches returned correctly",
+
+			namespace: "test",
+			vpa:       testVpa,
+			calculators: []patch.Calculator{
+				&fakePatchCalculator{[]resource_admission.PatchRecord{
+					testPatchRecord,
+					testPatchRecord2,
+				}, nil}},
+			podPreProcessorError: nil,
+			expectError:          nil,
+			expectPatches: []resource_admission.PatchRecord{
+				patch.GetAddEmptyAnnotationsPatch(),
+				testPatchRecord,
+				testPatchRecord2,
+			},
+		},
+		{
+			name: "patches returned correctly for multiple calculators",
+
+			namespace: "test",
+			vpa:       testVpa,
+			calculators: []patch.Calculator{
+				&fakePatchCalculator{[]resource_admission.PatchRecord{
+					testPatchRecord,
+				}, nil},
+				&fakePatchCalculator{[]resource_admission.PatchRecord{
+					testPatchRecord2,
+				}, nil}},
+			podPreProcessorError: nil,
+			expectError:          nil,
+			expectPatches: []resource_admission.PatchRecord{
+				patch.GetAddEmptyAnnotationsPatch(),
+				testPatchRecord,
+				testPatchRecord2,
+			},
+		},
+		{
+			name:      "patches returned correctly for spec",
+			namespace: "test",
+			vpa:       testVpa,
+			calculators: []patch.Calculator{
+				&fakePatchCalculator{[]resource_admission.PatchRecord{
+					testPatchRecordSpec,
+				}, nil},
+			},
+			podPreProcessorError: nil,
+			expectError:          nil,
+			expectPatches: []resource_admission.PatchRecord{
+				patch.GetAddEmptyAnnotationsPatch(),
+				{
+					Op:    testPatchRecordSpec.Op,
+					Path:  "/spec/template" + testPatchRecordSpec.Path,
+					Value: testPatchRecordSpec.Value,
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("test case: %s", tc.name), func(t *testing.T) {
+			fppp := &fakePodPreProcessor{tc.podPreProcessorError}
+			fvm := &fakeVpaMatcher{vpa: tc.vpa}
+			h := NewResourceHandler(fppp, fvm, tc.calculators)
+			patches, err := h.GetPatchesForWorkload(
+				tc.namespace,
+				&v1.ObjectMeta{
+					Name:         "",
+					GenerateName: "Foo",
+					Namespace:    "",
+				},
+				&apiv1.PodTemplateSpec{
+					Spec: apiv1.PodSpec{},
+				})
+			if tc.expectError == nil {
+				assert.NoError(t, err)
+			} else {
+				if assert.Error(t, err) {
+					assert.Equal(t, tc.expectError.Error(), err.Error())
+				}
+			}
+			if assert.Equal(t, len(tc.expectPatches), len(patches), fmt.Sprintf("got %+v, want %+v", patches, tc.expectPatches)) {
+				for i, gotPatch := range patches {
+					if !patch.EqPatch(gotPatch, tc.expectPatches[i]) {
+						t.Errorf("Expected patch at position %d to be %+v, got %+v", i, tc.expectPatches[i], gotPatch)
+					}
+				}
+			}
+		})
+	}
+}

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
@@ -120,7 +120,7 @@ type PodUpdatePolicy struct {
 }
 
 // UpdateMode controls when autoscaler applies changes to the pod resoures.
-// +kubebuilder:validation:Enum=Off;Initial;Recreate;Auto
+// +kubebuilder:validation:Enum=Off;Initial;Recreate;Auto;Trigger
 type UpdateMode string
 
 const (
@@ -137,9 +137,13 @@ const (
 	UpdateModeRecreate UpdateMode = "Recreate"
 	// UpdateModeAuto means that autoscaler assigns resources on pod creation
 	// and additionally can update them during the lifetime of the pod,
-	// using any available update method. Currently this is equivalent to
+	// using any available update method. Currently, this is equivalent to
 	// Recreate, which is the only available update method.
 	UpdateModeAuto UpdateMode = "Auto"
+	// UpdateModeTrigger means that the autoscaler assigns resource when
+	// the controlling workload (Deployement, Statefulset) or the pod has
+	// the `vpaTrigger: true` annotation.
+	UpdateModeTrigger UpdateMode = "Trigger"
 )
 
 // PodResourcePolicy controls how autoscaler computes the recommended resources

--- a/vertical-pod-autoscaler/pkg/utils/annotations/vpa_trigger.go
+++ b/vertical-pod-autoscaler/pkg/utils/annotations/vpa_trigger.go
@@ -22,8 +22,10 @@ import (
 
 const (
 	// VpaTriggerLabel is a label used by the vpa trigger annotation.
-	VpaTriggerLabel     = "vpaTrigger"
-	VpaTriggerEnabled   = "true"
+	VpaTriggerLabel = "vpaTrigger"
+	// VpaTriggerEnabled is the value of VpaTriggerLabel used to enable the tirgger.
+	VpaTriggerEnabled = "true"
+	// VpaTriggerTriggered is the value of VpaTriggerLabel set once we've triggered an update because of the annotation.
 	VpaTriggerTriggered = "triggered"
 )
 

--- a/vertical-pod-autoscaler/pkg/utils/annotations/vpa_trigger.go
+++ b/vertical-pod-autoscaler/pkg/utils/annotations/vpa_trigger.go
@@ -17,6 +17,8 @@ limitations under the License.
 package annotations
 
 import (
+	"time"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -26,7 +28,7 @@ const (
 	// VpaTriggerEnabled is the value of VpaTriggerLabel used to enable the tirgger.
 	VpaTriggerEnabled = "true"
 	// VpaTriggerTriggered is the value of VpaTriggerLabel set once we've triggered an update because of the annotation.
-	VpaTriggerTriggered = "triggered"
+	VpaTriggerTriggered = "triggered at"
 )
 
 // HasVpaTrigger creates an annotation value for a given pod.
@@ -35,4 +37,9 @@ func HasVpaTrigger(objectMeta *metav1.ObjectMeta) bool {
 		return true
 	}
 	return false
+}
+
+// GetVpaTriggeredValue returns the value for the VpaTriggerLabel annotation once it has been triggered at a given time.
+func GetVpaTriggeredValue(t time.Time) string {
+	return VpaTriggerTriggered + " " + t.Format(time.RFC3339)
 }

--- a/vertical-pod-autoscaler/pkg/utils/annotations/vpa_trigger.go
+++ b/vertical-pod-autoscaler/pkg/utils/annotations/vpa_trigger.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package annotations
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// VpaTriggerLabel is a label used by the vpa trigger annotation.
+	VpaTriggerLabel     = "vpaTrigger"
+	VpaTriggerEnabled   = "true"
+	VpaTriggerTriggered = "triggered"
+)
+
+// HasVpaTrigger creates an annotation value for a given pod.
+func HasVpaTrigger(objectMeta *metav1.ObjectMeta) bool {
+	if val, ok := objectMeta.Annotations[VpaTriggerLabel]; ok && val == VpaTriggerEnabled {
+		return true
+	}
+	return false
+}

--- a/vertical-pod-autoscaler/pkg/utils/annotations/vpa_trigger_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/annotations/vpa_trigger_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package annotations
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
+)
+
+func TestHasVpaTrigger(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  *v1.Pod
+		want bool
+	}{
+		{
+			name: "without annotation",
+			pod:  test.Pod().Get(),
+			want: false,
+		},
+		{
+			name: "with annotation false",
+			pod:  test.Pod().WithAnnotations(map[string]string{VpaTriggerLabel: "false"}).Get(),
+			want: false,
+		},
+		{
+			name: "with annotation true",
+			pod:  test.Pod().WithAnnotations(map[string]string{VpaTriggerLabel: "true"}).Get(),
+			want: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("test case: %s", tc.name), func(t *testing.T) {
+			got := HasVpaTrigger(&tc.pod.ObjectMeta)
+			assert.Equal(t, got, tc.want)
+		})
+	}
+}

--- a/vertical-pod-autoscaler/pkg/utils/metrics/admission/admission.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/admission/admission.go
@@ -58,6 +58,10 @@ const (
 	Pod AdmissionResource = "Pod"
 	// Vpa means VerticalPodAutoscaler object (CRD)
 	Vpa AdmissionResource = "VPA"
+	// Deployment means Kubernetes Deployment
+	Deployment AdmissionResource = "Deployment"
+	// StatefulSet means Kubernetes Deployment
+	StatefulSet AdmissionResource = "StatefulSet"
 )
 
 var (
@@ -67,6 +71,14 @@ var (
 			Name:      "admission_pods_total",
 			Help:      "Number of Pods processed by VPA Admission Controller.",
 		}, []string{"applied"},
+	)
+
+	admissionWorkloadCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "admission_workload_total",
+			Help:      "Number of Workload (Deployment, StatefulSet, DaemonSet) processed by VPA Admission Controller.",
+		}, []string{"applied", "resource"},
 	)
 
 	admissionLatency = prometheus.NewHistogramVec(
@@ -82,12 +94,18 @@ var (
 // Register initializes all metrics for VPA Admission Contoller
 func Register() {
 	prometheus.MustRegister(admissionCount)
+	prometheus.MustRegister(admissionWorkloadCount)
 	prometheus.MustRegister(admissionLatency)
 }
 
 // OnAdmittedPod increases the counter of pods handled by VPA Admission Controller
 func OnAdmittedPod(touched bool) {
 	admissionCount.WithLabelValues(fmt.Sprintf("%v", touched)).Add(1)
+}
+
+// OnAdmittedWorkload increases the counter of workloads handled by VPA Admission Controller
+func OnAdmittedWorkload(touched bool, resource AdmissionResource) {
+	admissionWorkloadCount.WithLabelValues(fmt.Sprintf("%v", touched), string(resource)).Add(1)
 }
 
 // NewAdmissionLatency provides a timer for admission latency; call Observe() on it to measure


### PR DESCRIPTION
#### Which component this PR applies to?

vertical-pod-autoscaler

#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it:

Setting the `vpaTrigger:true` annotation will trigger a recommendation
on a pod, deployment or statefulset.

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

See vertical-pod-autoscaler/enhancements/xxxx-update-mode-trigger/README.md