### PR TITLE
[local] 1.26 podtopologyspread backwards compatibility - hack

### DIFF
--- a/cluster-autoscaler/vendor/k8s.io/kubernetes/pkg/scheduler/framework/plugins/podtopologyspread/plugin.go
+++ b/cluster-autoscaler/vendor/k8s.io/kubernetes/pkg/scheduler/framework/plugins/podtopologyspread/plugin.go
@@ -18,6 +18,7 @@ package podtopologyspread
 
 import (
 	"fmt"
+	"os"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -101,6 +102,13 @@ func New(plArgs runtime.Object, h framework.Handle, fts feature.Features) (frame
 		enableNodeInclusionPolicyInPodTopologySpread: fts.EnableNodeInclusionPolicyInPodTopologySpread,
 		enableMatchLabelKeysInPodTopologySpread:      fts.EnableMatchLabelKeysInPodTopologySpread,
 	}
+
+	// enableMatchLabelKeysInPodTopologySpread is enabled by default in kube 1.26, but to keep the CA scheduler behavior
+	// in line with clusters older than 1.26, this flag can be overridden to disable the new scheduling behavior
+	if os.Getenv("SPREADTOPOLOGY_NODE_INCLUSION_POLICY") == "disabled" {
+		pl.enableNodeInclusionPolicyInPodTopologySpread = false
+	}
+	
 	if args.DefaultingType == config.SystemDefaulting {
 		pl.defaultConstraints = systemDefaultConstraints
 		pl.systemDefaulted = true


### PR DESCRIPTION
Kube 1.26 introduces more changes to the scheduler around podtopologyspread, and has the new option 'enableNodeInclusionPolicyInPodTopologySpread' enabled by default (starting with kube 1.26). When enabled, this changes how nodeAffinities are treated when scheduling pods and could result in a situation where the CA believes a pod should be scheduleable, but our older k8s cluster's schedulers do not, so the pod will stay Pending indefinitely.

In a similar manner to the other backwards compatibility change (9ca8a203ffb51db95114b42dd2e70acca28e8cee), this adds an environment variable to explicitly disable this behavior on older clusters.  The Node Inclusion Policy code is gated behind the feature flag `enableNodeInclusionPolicyInPodTopologySpread`, so it turning it off does not require a large number of changes (an environment variable `SPREADTOPOLOGY_NODE_INCLUSION_POLICY` forces this to disabled in the plugin's `New` function)
