### PR TITLE
recommender-external: start reading external metrics

### DIFF
--- a/vertical-pod-autoscaler/deploy/vpa-rbac.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-rbac.yaml
@@ -15,6 +15,33 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: system:external-metrics-reader
+rules:
+  - apiGroups:
+      - "external.metrics.k8s.io"
+    resources:
+      - "*"
+    verbs:
+      - list
+      - get
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:external-metrics-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:external-metrics-reader
+subjects:
+  - kind: ServiceAccount
+    name: vpa-recommender
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   name: system:vpa-actor
 rules:
   - apiGroups:
@@ -157,12 +184,12 @@ metadata:
   name: system:vpa-target-reader
 rules:
   - apiGroups:
-    - '*'
+      - '*'
     resources:
-    - '*/scale'
+      - '*/scale'
     verbs:
-    - get
-    - watch
+      - get
+      - watch
   - apiGroups:
       - ""
     resources:

--- a/vertical-pod-autoscaler/examples/hamster-external-metrics.yaml
+++ b/vertical-pod-autoscaler/examples/hamster-external-metrics.yaml
@@ -1,0 +1,114 @@
+# This config creates a deployment with two pods, each requesting 100 millicores
+# and trying to utilize slightly above 500 millicores (repeatedly using CPU for
+# 0.5s and sleeping 0.5s).
+# It also creates a corresponding Vertical Pod Autoscaler that adjusts the
+# requests.
+# Note that the update mode is left unset, so it defaults to "Auto" mode.
+---
+apiVersion: "autoscaling.k8s.io/v1"
+kind: VerticalPodAutoscaler
+metadata:
+  name: hamster-vpa
+  annotations:
+    vpa.datadoghq.com/metric-cpu-hamster: datadogmetric@default:hamster-cpu
+    vpa.datadoghq.com/metric-memory-hamster: datadogmetric@default:hamster-memory
+spec:
+  # recommenders field can be unset when using the default recommender.
+  # When using an alternative recommender, the alternative recommender's name
+  # can be specified as the following in a list.
+  # recommenders:
+  #   - name: 'alternative'
+  targetRef:
+    apiVersion: "apps/v1"
+    kind: Deployment
+    name: hamster
+  recommenders:
+    - name: recommender-external
+  updatePolicy:
+    updateMode: Recreate
+  resourcePolicy:
+    containerPolicies:
+      - containerName: '*'
+        minAllowed:
+          cpu: 100m
+          memory: 50Mi
+        maxAllowed:
+          cpu: 1
+          memory: 500Mi
+        controlledResources: [ "cpu", "memory" ]
+---
+# Associated DatadogMetric
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogMetric
+metadata:
+  name: hamster-cpu
+spec:
+  # We scale down the nanocore value to millicores (it's actually nanoseconds per second)
+  query: avg:container.cpu.usage{host:minikube,container_name:k8s_hamster*}.rollup(max, 60) / 1000000
+  maxAge: "10m"
+---
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogMetric
+metadata:
+  name: hamster-memory
+spec:
+  query: avg:container.memory.usage{host:minikube,container_name:k8s_hamster*}.rollup(max, 60)
+  maxAge: "10m"
+---
+# Fake HPA to enable the DatadogMetric
+# TODO: Remove these once we have a way to enable the DatadogMetric without HPA/WPA
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: hpa-fake-hamster
+spec:
+  metrics:
+    - external:
+        metric:
+          name: datadogmetric@default:hamster-cpu
+        target:
+          averageValue: "1"
+          type: AverageValue
+      type: External
+    - external:
+        metric:
+          name: datadogmetric@default:hamster-memory
+        target:
+          averageValue: "1"
+          type: AverageValue
+      type: External
+  minReplicas: 1
+  maxReplicas: 1
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: fake
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hamster
+spec:
+  selector:
+    matchLabels:
+      app: hamster
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: hamster
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534 # nobody
+      containers:
+        - name: hamster
+          image: k8s.gcr.io/ubuntu-slim:0.1
+          resources:
+            requests:
+              cpu: 100m
+              memory: 50Mi
+          command: [ "/bin/sh" ]
+          args:
+            - "-c"
+            - "while true; do timeout 0.5s yes >/dev/null; sleep 0.5s; done"

--- a/vertical-pod-autoscaler/pkg/recommender-external/Dockerfile
+++ b/vertical-pod-autoscaler/pkg/recommender-external/Dockerfile
@@ -19,4 +19,4 @@ ARG ARCH
 COPY recommender-external-$ARCH /recommender-external
 
 ENTRYPOINT ["/recommender-external"]
-CMD ["--v=4", "--stderrthreshold=info"]
+CMD ["--v=10", "--stderrthreshold=info", "--pod-recommendation-min-memory-mb=0.0001"]

--- a/vertical-pod-autoscaler/pkg/recommender-external/input/annotations.go
+++ b/vertical-pod-autoscaler/pkg/recommender-external/input/annotations.go
@@ -67,6 +67,10 @@ func (c ContainersToResourcesAndMetrics) parseAnnotationKV(k, v string) error {
 	return nil
 }
 
+func AnnotationKey(container string, cpu upstream_model.ResourceName) string {
+	return VpaAnnotationPrefix + string(cpu) + "-" + container
+}
+
 // parseAnnotationKey parses a container, resource to metric annotation
 func parseAnnotationKey(k string) (container string, resource upstream_model.ResourceName, err error) {
 	// Here we have vpa.datadoghq.com/metric-* and we expect * to match <resource>-<container>

--- a/vertical-pod-autoscaler/pkg/recommender-external/input/annotations.go
+++ b/vertical-pod-autoscaler/pkg/recommender-external/input/annotations.go
@@ -67,6 +67,7 @@ func (c ContainersToResourcesAndMetrics) parseAnnotationKV(k, v string) error {
 	return nil
 }
 
+// AnnotationKey creates an annotation key from a container and resource name.
 func AnnotationKey(container string, cpu upstream_model.ResourceName) string {
 	return VpaAnnotationPrefix + string(cpu) + "-" + container
 }

--- a/vertical-pod-autoscaler/pkg/recommender-external/input/annotations.go
+++ b/vertical-pod-autoscaler/pkg/recommender-external/input/annotations.go
@@ -41,13 +41,18 @@ var (
 	SupportedResources = []upstream_model.ResourceName{upstream_model.ResourceCPU, upstream_model.ResourceMemory}
 )
 
+// ContainersToResourcesAndMetrics maps a contaienr name to associated resource names and metrics.
 type ContainersToResourcesAndMetrics map[string]map[upstream_model.ResourceName]string
+
+// AnnotationsMap is simply a map of annotations to values
 type AnnotationsMap map[string]string
 
+// NewContainersToResourcesAndMetrics creates a ContainersToResourcesAndMetrics
 func NewContainersToResourcesAndMetrics() ContainersToResourcesAndMetrics {
 	return make(ContainersToResourcesAndMetrics)
 }
 
+// AddMetric adds a container, resource and associated metric
 func (c ContainersToResourcesAndMetrics) AddMetric(container string, resource upstream_model.ResourceName, metric string) {
 	if _, ok := c[container]; !ok {
 		c[container] = make(map[upstream_model.ResourceName]string)
@@ -55,6 +60,7 @@ func (c ContainersToResourcesAndMetrics) AddMetric(container string, resource up
 	c[container][resource] = metric
 }
 
+// ParseAndFromAnnotation parses a container, resource to metric annotation
 func (c ContainersToResourcesAndMetrics) ParseAndFromAnnotation(k, v string) error {
 	container, resource, err := ParseAnnotation(k)
 	if err != nil {
@@ -64,6 +70,7 @@ func (c ContainersToResourcesAndMetrics) ParseAndFromAnnotation(k, v string) err
 	return nil
 }
 
+// ParseAnnotation parses a container, resource to metric annotation
 func ParseAnnotation(k string) (container string, resource upstream_model.ResourceName, err error) {
 	// Here we have `vpa.datadoghq.com/metric-<resource>-<container>`
 
@@ -83,10 +90,12 @@ func ParseAnnotation(k string) (container string, resource upstream_model.Resour
 	return "", "", fmt.Errorf("can't recognize %s", k)
 }
 
+// IsVpaExternalMetricAnnotation returns true if an annotation configures a metric for a container and resource
 func IsVpaExternalMetricAnnotation(annotation string) bool {
 	return strings.HasPrefix(annotation, VpaAnnotationPrefix)
 }
 
+// GetVpaExternalMetrics returns the map of containers, resource to metrics
 func GetVpaExternalMetrics(annotations AnnotationsMap) ContainersToResourcesAndMetrics {
 	c := NewContainersToResourcesAndMetrics()
 	for k, v := range annotations {

--- a/vertical-pod-autoscaler/pkg/recommender-external/input/annotations.go
+++ b/vertical-pod-autoscaler/pkg/recommender-external/input/annotations.go
@@ -103,13 +103,15 @@ func GetVpaExternalMetrics(annotations map[string]string) ContainersToResourcesA
 	c := NewContainersToResourcesAndMetrics()
 	for k, v := range annotations {
 		if isVpaExternalMetricAnnotation(k) {
-			klog.V(6).Infof("Found %s:%s", k, v)
+			klog.V(6).Infof("Found annotation with relevant prefix %s:%s", k, v)
 			err := c.parseAnnotationKV(k, v)
 			if err != nil {
 				klog.V(2).ErrorS(err, fmt.Sprintf("Can't parse %s:%s", k, v))
 			}
 		}
 	}
-	klog.V(6).Infof("Found %+v", c)
+	if len(c) > 0 {
+		klog.V(6).Infof("Found %+v", c)
+	}
 	return c
 }

--- a/vertical-pod-autoscaler/pkg/recommender-external/input/annotations_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender-external/input/annotations_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/vertical-pod-autoscaler/pkg/recommender-external/input/annotations_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender-external/input/annotations_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package input
 
 import (

--- a/vertical-pod-autoscaler/pkg/recommender-external/input/annotations_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender-external/input/annotations_test.go
@@ -1,0 +1,48 @@
+package input
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
+)
+
+func TestGetVpaExternalMetrics(t *testing.T) {
+	type args struct {
+		annotations map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want ContainersToResourcesAndMetrics
+	}{
+		{
+			name: "empty",
+			args: args{
+				annotations: map[string]string{},
+			},
+			want: ContainersToResourcesAndMetrics{},
+		},
+		{
+			name: "some annotations",
+			args: args{
+				annotations: map[string]string{
+					AnnotationKey("container1", model.ResourceCPU):    "system-cpu",
+					AnnotationKey("container1", model.ResourceMemory): "system-memory",
+				},
+			},
+			want: ContainersToResourcesAndMetrics{
+				"container1": {
+					model.ResourceCPU:    "system-cpu",
+					model.ResourceMemory: "system-memory",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, GetVpaExternalMetrics(tt.args.annotations), "GetVpaExternalMetrics(%v)", tt.args.annotations)
+		})
+	}
+}

--- a/vertical-pod-autoscaler/pkg/recommender-external/input/annotations_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender-external/input/annotations_test.go
@@ -26,27 +26,22 @@ import (
 
 func TestGetVpaExternalMetrics(t *testing.T) {
 	type args struct {
-		annotations map[string]string
 	}
 	tests := []struct {
-		name string
-		args args
-		want ContainersToResourcesAndMetrics
+		name        string
+		annotations map[string]string
+		want        ContainersToResourcesAndMetrics
 	}{
 		{
-			name: "empty",
-			args: args{
-				annotations: map[string]string{},
-			},
-			want: ContainersToResourcesAndMetrics{},
+			name:        "empty",
+			annotations: map[string]string{},
+			want:        ContainersToResourcesAndMetrics{},
 		},
 		{
 			name: "some annotations",
-			args: args{
-				annotations: map[string]string{
-					AnnotationKey("container1", model.ResourceCPU):    "system-cpu",
-					AnnotationKey("container1", model.ResourceMemory): "system-memory",
-				},
+			annotations: map[string]string{
+				AnnotationKey("container1", model.ResourceCPU):    "system-cpu",
+				AnnotationKey("container1", model.ResourceMemory): "system-memory",
 			},
 			want: ContainersToResourcesAndMetrics{
 				"container1": {
@@ -58,7 +53,7 @@ func TestGetVpaExternalMetrics(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, GetVpaExternalMetrics(tt.args.annotations), "GetVpaExternalMetrics(%v)", tt.args.annotations)
+			assert.Equalf(t, tt.want, GetVpaExternalMetrics(tt.annotations), "GetVpaExternalMetrics(%v)", tt.annotations)
 		})
 	}
 }

--- a/vertical-pod-autoscaler/pkg/recommender-external/input/metrics/annotations_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender-external/input/metrics/annotations_test.go
@@ -1,0 +1,3 @@
+package metrics
+
+// ParseAndFromAnnotation

--- a/vertical-pod-autoscaler/pkg/recommender-external/input/metrics/annotations_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender-external/input/metrics/annotations_test.go
@@ -1,3 +1,0 @@
-package metrics
-
-// ParseAndFromAnnotation

--- a/vertical-pod-autoscaler/pkg/recommender-external/input/metrics/external_metrics_client.go
+++ b/vertical-pod-autoscaler/pkg/recommender-external/input/metrics/external_metrics_client.go
@@ -21,15 +21,15 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/klog/v2"
 	externalclient "k8s.io/metrics/pkg/client/external_metrics"
 
 	recommender_metrics "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/recommender"
 )
 
-// MetricsClient provides simple metrics on resources usage on containter level.
+// MetricsClient provides simple metrics on resources usage on container level. It always returns the last point only.
 type MetricsClient interface {
-	// GetExternalMetrics returns FIXME really return stuff
-	GetExternalMetric(metricName, namespace string, selector labels.Selector) ([]int64, time.Time, error)
+	GetExternalMetric(metricName, namespace string, selector labels.Selector) (int64, time.Time, error)
 }
 
 // NewMetricsClient creates a new external metric client.
@@ -49,23 +49,22 @@ type metricsClient struct {
 
 // GetExternalMetric gets all the values of a given external metric
 // that match the specified selector.
-// TODO: Review all that when we actually use it
-func (c *metricsClient) GetExternalMetric(metricName, namespace string, selector labels.Selector) ([]int64, time.Time, error) {
+func (c *metricsClient) GetExternalMetric(metricName, namespace string, selector labels.Selector) (int64, time.Time, error) {
 	metrics, err := c.client.NamespacedMetrics(namespace).List(metricName, selector)
 	recommender_metrics.RecordMetricsServerResponse(err, c.clientName)
 	if err != nil {
-		return []int64{}, time.Time{}, fmt.Errorf("unable to fetch metrics from external metrics API: %v", err)
+		return 0, time.Time{}, fmt.Errorf("unable to fetch metrics from external metrics API: %v", err)
 	}
 
 	if len(metrics.Items) == 0 {
-		return nil, time.Time{}, fmt.Errorf("no metrics returned from external metrics API")
+		return 0, time.Time{}, fmt.Errorf("no metrics returned from external metrics API")
 	}
 
-	res := make([]int64, 0)
-	for _, m := range metrics.Items {
-		res = append(res, m.Value.MilliValue())
-	}
-	timestamp := metrics.Items[0].Timestamp.Time
-	// TODO: Change (or wrap) this function to return Resources instead.
-	return res, timestamp, nil
+	klog.V(6).Infof("Got %d points: %+v", len(metrics.Items), metrics.Items)
+
+	idx := len(metrics.Items) - 1
+	value := metrics.Items[idx].Value.Value()
+	timestamp := metrics.Items[idx].Timestamp.Time
+
+	return value, timestamp, nil
 }

--- a/vertical-pod-autoscaler/pkg/recommender-external/input/metrics/external_metrics_client.go
+++ b/vertical-pod-autoscaler/pkg/recommender-external/input/metrics/external_metrics_client.go
@@ -56,13 +56,15 @@ func (c *metricsClient) GetExternalMetric(metricName, namespace string, selector
 		return 0, time.Time{}, fmt.Errorf("unable to fetch metrics from external metrics API: %v", err)
 	}
 
-	if len(metrics.Items) == 0 {
+	points := len(metrics.Items)
+	idx := points - 1
+
+	if points == 0 {
 		return 0, time.Time{}, fmt.Errorf("no metrics returned from external metrics API")
 	}
 
-	klog.V(6).Infof("Got %d points: %+v", len(metrics.Items), metrics.Items)
+	klog.V(6).Infof("Got %d points, taking the last one: %+v", points, metrics.Items[idx])
 
-	idx := len(metrics.Items) - 1
 	value := metrics.Items[idx].Value.Value()
 	timestamp := metrics.Items[idx].Timestamp.Time
 

--- a/vertical-pod-autoscaler/pkg/recommender-external/input/metrics/external_metrics_client_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender-external/input/metrics/external_metrics_client_test.go
@@ -15,3 +15,30 @@ limitations under the License.
 */
 
 package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func TestGetEmptyMetric(t *testing.T) {
+	tc := NewEmptyMetricsClientTestCase()
+	emptyMetricsClient := tc.CreateFakeMetricsClient()
+
+	_, _, err := emptyMetricsClient.GetExternalMetric("qps", "fake", labels.Everything())
+
+	assert.Error(t, err)
+}
+
+func TestGetMetric(t *testing.T) {
+	tc := NewMetricsClientTestCase()
+	fakeMetricsClient := tc.CreateFakeMetricsClient()
+
+	value, time, err := fakeMetricsClient.GetExternalMetric("qps", "fake", labels.Everything())
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, value)
+	assert.NotZero(t, time)
+}

--- a/vertical-pod-autoscaler/pkg/recommender-external/input/metrics/external_metrics_client_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender-external/input/metrics/external_metrics_client_test.go
@@ -39,6 +39,6 @@ func TestGetMetric(t *testing.T) {
 	value, time, err := fakeMetricsClient.GetExternalMetric("qps", "fake", labels.Everything())
 
 	assert.NoError(t, err)
-	assert.Equal(t, 1, value)
+	assert.Equal(t, int64(1), value)
 	assert.NotZero(t, time)
 }

--- a/vertical-pod-autoscaler/pkg/recommender-external/input/metrics/external_metrics_client_test_util.go
+++ b/vertical-pod-autoscaler/pkg/recommender-external/input/metrics/external_metrics_client_test_util.go
@@ -15,3 +15,80 @@ limitations under the License.
 */
 
 package metrics
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	core "k8s.io/client-go/testing"
+	emapi "k8s.io/metrics/pkg/apis/external_metrics/v1beta1"
+	emfake "k8s.io/metrics/pkg/client/external_metrics/fake"
+)
+
+type metricsQueryTestCase struct {
+	value int64
+	time  time.Time
+	error error
+}
+type metricsClientTestCase struct {
+	metrics map[string]metricsQueryTestCase
+}
+
+func NewMetricsClientTestCase() *metricsClientTestCase {
+
+	testCase := &metricsClientTestCase{
+		metrics: make(map[string]metricsQueryTestCase),
+	}
+
+	testCase.metrics["qps"] = metricsQueryTestCase{
+		value: 1,
+		time:  time.Now(),
+		error: nil,
+	}
+	testCase.metrics["system.cpu"] = metricsQueryTestCase{
+		value: 1,
+		time:  time.Now(),
+		error: nil,
+	}
+	testCase.metrics["system.mem"] = metricsQueryTestCase{
+		value: 1,
+		time:  time.Now(),
+		error: nil,
+	}
+	return testCase
+}
+
+func NewEmptyMetricsClientTestCase() *metricsClientTestCase {
+	return &metricsClientTestCase{}
+}
+
+func (tc *metricsClientTestCase) CreateFakeMetricsClient() MetricsClient {
+	fakeEMClient := &emfake.FakeExternalMetricsClient{}
+	fakeEMClient.AddReactor("list", "*", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+		listAction, wasList := action.(core.ListAction)
+		if !wasList {
+			return true, nil, fmt.Errorf("expected a list action, got %v instead", action)
+		}
+
+		metrics := &emapi.ExternalMetricValueList{}
+
+		q := listAction.GetResource().Resource
+
+		value, found := tc.metrics[q]
+
+		if found && value.error == nil {
+			metric := emapi.ExternalMetricValue{
+				Timestamp:  metav1.Time{Time: value.time},
+				MetricName: q,
+				Value:      *resource.NewMilliQuantity(int64(value.value), resource.DecimalSI),
+			}
+			metrics.Items = append(metrics.Items, metric)
+		}
+
+		return true, metrics, value.error
+	})
+	return NewMetricsClient(fakeEMClient, "", "fake")
+}

--- a/vertical-pod-autoscaler/pkg/recommender-external/input/metrics/external_metrics_client_test_util.go
+++ b/vertical-pod-autoscaler/pkg/recommender-external/input/metrics/external_metrics_client_test_util.go
@@ -37,6 +37,7 @@ type metricsClientTestCase struct {
 	metrics map[string]metricsQueryTestCase
 }
 
+// NewMetricsClientTestCase creates a new test case with pre-defined metrics.
 func NewMetricsClientTestCase() *metricsClientTestCase {
 
 	testCase := &metricsClientTestCase{
@@ -61,6 +62,7 @@ func NewMetricsClientTestCase() *metricsClientTestCase {
 	return testCase
 }
 
+// NewEmptyMetricsClientTestCase creates a new  test cacse with no metrics.
 func NewEmptyMetricsClientTestCase() *metricsClientTestCase {
 	return &metricsClientTestCase{}
 }

--- a/vertical-pod-autoscaler/pkg/recommender-external/input/metrics/external_metrics_client_test_util.go
+++ b/vertical-pod-autoscaler/pkg/recommender-external/input/metrics/external_metrics_client_test_util.go
@@ -81,14 +81,16 @@ func (tc *metricsClientTestCase) CreateFakeMetricsClient() MetricsClient {
 
 		value, found := tc.metrics[q]
 
-		if found && value.error == nil {
-			metric := emapi.ExternalMetricValue{
-				Timestamp:  metav1.Time{Time: value.time},
-				MetricName: q,
-				Value:      *resource.NewMilliQuantity(int64(value.value), resource.DecimalSI),
-			}
-			metrics.Items = append(metrics.Items, metric)
+		if !found || value.error != nil {
+			return true, metrics, value.error
 		}
+
+		metric := emapi.ExternalMetricValue{
+			Timestamp:  metav1.Time{Time: value.time},
+			MetricName: q,
+			Value:      *resource.NewMilliQuantity(int64(value.value), resource.DecimalSI),
+		}
+		metrics.Items = append(metrics.Items, metric)
 
 		return true, metrics, value.error
 	})

--- a/vertical-pod-autoscaler/pkg/recommender-external/input/recommendations_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender-external/input/recommendations_feeder.go
@@ -95,7 +95,7 @@ func (e externalRecommendationsStateFeeder) LoadMetrics() {
 	for _, vpa := range e.clusterState.Vpas {
 		klog.V(1).Infof("vpa %s %d", vpa.ID.VpaName, vpa.PodCount)
 
-		containersToResourcesAndMetrics := GetVpaExternalMetrics(AnnotationsMap(vpa.Annotations))
+		containersToResourcesAndMetrics := GetVpaExternalMetrics(vpa.Annotations)
 		errs := e.loadMetrics(vpa, containersToResourcesAndMetrics)
 
 		for _, err := range errs {
@@ -107,7 +107,8 @@ func (e externalRecommendationsStateFeeder) LoadMetrics() {
 }
 
 func (e externalRecommendationsStateFeeder) loadMetrics(vpa *upstream_model.Vpa, containersToResourcesAndMetrics ContainersToResourcesAndMetrics) []error {
-	errs := make([]error, 0)
+	var errs []error
+
 	for container, resourceToMetrics := range containersToResourcesAndMetrics {
 		recommendation := make(upstream_model.Resources)
 		for resource, metric := range resourceToMetrics {
@@ -129,7 +130,7 @@ func (e externalRecommendationsStateFeeder) loadMetrics(vpa *upstream_model.Vpa,
 func (e externalRecommendationsStateFeeder) loadMetric(vpa *upstream_model.Vpa, resource upstream_model.ResourceName, metric string) (upstream_model.ResourceAmount, error) {
 	metricName, metricSelector, err := e.getMetricNameAndSelector(metric)
 	if err != nil {
-		return -1, err
+		return 0, err
 	}
 
 	value, _, err := e.metricsClient.GetExternalMetric(metricName, vpa.ID.Namespace, metricSelector)

--- a/vertical-pod-autoscaler/pkg/recommender-external/input/recommendations_feeder_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender-external/input/recommendations_feeder_test.go
@@ -25,16 +25,22 @@ import (
 
 	"k8s.io/apimachinery/pkg/labels"
 
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender-external/input/metrics"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender-external/model"
 	upstream_model "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
 )
 
 const (
-	testGcPeriod = time.Minute
+	testGcPeriod  = time.Minute
+	ContainerName = "container-1"
 )
 
-func TestExternalRecommendationsFeeder_LoadVPAs(t *testing.T) {
+var (
+	VpaID1 = upstream_model.VpaID{VpaName: fmt.Sprintf("test-vpa-1"), Namespace: "default"}
+	VpaID2 = upstream_model.VpaID{VpaName: fmt.Sprintf("test-vpa-2"), Namespace: "default"}
+)
 
+func createFeeder(t *testing.T) *externalRecommendationsStateFeeder {
 	clusterState := upstream_model.NewClusterState(testGcPeriod)
 
 	podSelector1, err := labels.Parse("name=vpa-pod-1")
@@ -43,16 +49,48 @@ func TestExternalRecommendationsFeeder_LoadVPAs(t *testing.T) {
 	assert.NoError(t, err)
 
 	clusterState.Vpas = map[upstream_model.VpaID]*upstream_model.Vpa{
-		{VpaName: fmt.Sprintf("test-vpa-1"), Namespace: "default"}: {PodSelector: podSelector1},
-		{VpaName: fmt.Sprintf("test-vpa-1"), Namespace: "default"}: {PodSelector: podSelector2},
+		VpaID1: {
+			ID:          VpaID1,
+			PodSelector: podSelector1,
+			Annotations: map[string]string{
+				AnnotationKey(ContainerName, upstream_model.ResourceCPU):    "system.cpu",
+				AnnotationKey(ContainerName, upstream_model.ResourceMemory): "system.mem",
+			},
+		},
+		VpaID2: {
+			ID:          VpaID2,
+			PodSelector: podSelector2,
+		},
 	}
 
 	externalRecommendationState := model.NewExternalRecommendationsState(testGcPeriod)
 	feeder := externalRecommendationsStateFeeder{
 		clusterState:                 clusterState,
 		externalRecommendationsState: externalRecommendationState,
+		metricsClient:                metrics.NewMetricsClientTestCase().CreateFakeMetricsClient(),
 	}
+	return &feeder
+}
+func TestExternalRecommendationsFeeder_LoadVPAs(t *testing.T) {
+	feeder := createFeeder(t)
 
 	feeder.LoadVPAs()
-	assert.Len(t, feeder.externalRecommendationsState.Vpas, len(clusterState.Vpas))
+	assert.Len(t, feeder.externalRecommendationsState.Vpas, len(feeder.clusterState.Vpas))
+}
+
+func TestExternalRecommendationsFeeder_LoadMetrics(t *testing.T) {
+	feeder := createFeeder(t)
+
+	feeder.LoadVPAs()
+	feeder.LoadMetrics()
+
+	vpaId := upstream_model.VpaID{Namespace: "default", VpaName: "test-vpa-1"}
+
+	expected := upstream_model.Resources{
+		upstream_model.ResourceCPU:    upstream_model.ResourceAmount(1),
+		upstream_model.ResourceMemory: upstream_model.ResourceAmount(1),
+	}
+	assert.Contains(t, feeder.externalRecommendationsState.Vpas, vpaId)
+	assert.Contains(t, feeder.externalRecommendationsState.Vpas[vpaId].Containers, ContainerName)
+	assert.Equal(t, expected, feeder.externalRecommendationsState.Vpas[vpaId].Containers[ContainerName].RawRecommendation)
 }

--- a/vertical-pod-autoscaler/pkg/recommender-external/logic/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender-external/logic/recommender.go
@@ -55,6 +55,7 @@ func NewPodResourceRecommender(containerNameToRecommendedResources model.Contain
 func (r *podResourceRecommender) GetRecommendedPodResources(containerNameToAggregateStateMap upstream_model.ContainerNameToAggregateStateMap) upstream_logic.RecommendedPodResources {
 	var recommendation = make(upstream_logic.RecommendedPodResources)
 	if len(r.containerNameToRecommendedResources) == 0 {
+		klog.V(5).Infof("Returning empty recommendations.")
 		return recommendation
 	}
 

--- a/vertical-pod-autoscaler/pkg/recommender-external/routines/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender-external/routines/recommender.go
@@ -109,14 +109,14 @@ func (r *recommender) UpdateVPAs() {
 			continue
 		}
 
-		klog.V(5).Infof("Found for %+v: %q", key, vpaRecommendation.Containers)
+		klog.V(5).Infof("Container(s) found for vpa %+v: %q", key, vpaRecommendation.Containers)
 
 		resources := r.podResourceRecommenderFactory.
 			Make(GetContainerNameToRecommendedResources(vpa, vpaRecommendation)).
 			GetRecommendedPodResources(GetContainerNameToAggregateStateMap(vpa))
 		had := vpa.HasRecommendation()
 
-		klog.V(5).Infof("Found recommendation %+v (had: %v)", resources, had)
+		klog.V(5).Infof("Found recommendation for %+v: %+v (had: %v)", key, resources, had)
 
 		listOfResourceRecommendation := upstream_logic.MapToListOfRecommendedContainerResources(resources)
 
@@ -124,7 +124,7 @@ func (r *recommender) UpdateVPAs() {
 			listOfResourceRecommendation = postProcessor.Process(vpa, listOfResourceRecommendation, observedVpa.Spec.ResourcePolicy)
 		}
 
-		klog.V(5).Infof("Updating with recommendation %+v", listOfResourceRecommendation)
+		klog.V(5).Infof("Updating %+v with recommendation %+v", key, listOfResourceRecommendation)
 
 		vpa.UpdateRecommendation(listOfResourceRecommendation)
 		if vpa.HasRecommendation() && !had {

--- a/vertical-pod-autoscaler/pkg/recommender-external/routines/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender-external/routines/recommender.go
@@ -95,6 +95,8 @@ func (r *recommender) UpdateVPAs() {
 			VpaName:   observedVpa.Name,
 		}
 
+		klog.V(5).Infof("Observing %+v", key)
+
 		vpa, found := r.clusterState.Vpas[key]
 		if !found {
 			klog.Infof("We do not know this VPA yet: %+v", key)
@@ -107,16 +109,22 @@ func (r *recommender) UpdateVPAs() {
 			continue
 		}
 
+		klog.V(5).Infof("Found for %+v: %q", key, vpaRecommendation.Containers)
+
 		resources := r.podResourceRecommenderFactory.
 			Make(GetContainerNameToRecommendedResources(vpa, vpaRecommendation)).
-			GetRecommendedPodResources(upstream_routines.GetContainerNameToAggregateStateMap(vpa))
+			GetRecommendedPodResources(GetContainerNameToAggregateStateMap(vpa))
 		had := vpa.HasRecommendation()
+
+		klog.V(5).Infof("Found recommendation %+v (had: %v)", resources, had)
 
 		listOfResourceRecommendation := upstream_logic.MapToListOfRecommendedContainerResources(resources)
 
 		for _, postProcessor := range r.recommendationPostProcessor {
 			listOfResourceRecommendation = postProcessor.Process(vpa, listOfResourceRecommendation, observedVpa.Spec.ResourcePolicy)
 		}
+
+		klog.V(5).Infof("Updating with recommendation %+v", listOfResourceRecommendation)
 
 		vpa.UpdateRecommendation(listOfResourceRecommendation)
 		if vpa.HasRecommendation() && !had {
@@ -172,7 +180,7 @@ func (r *recommender) RunOnce() {
 	r.UpdateVPAs()
 	timer.ObserveStep("UpdateVPAs")
 
-	klog.V(3).Infof("ClusterState is tracking %d aggregated container states", r.clusterState.StateMapSize())
+	klog.V(3).Infof("ClusterState is tracking %d - %d aggregated container states", r.clusterState.StateMapSize(), r.externalRecommendationsState.Size())
 }
 
 func (r *recommender) ObserverOOM(containerID upstream_model.ContainerID, timestamp time.Time, requestedMemory upstream_model.ResourceAmount) error {

--- a/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
@@ -24,6 +24,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	metrics_quality "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/quality"
 	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"

--- a/vertical-pod-autoscaler/vendor/k8s.io/metrics/pkg/client/external_metrics/fake/fake_client.go
+++ b/vertical-pod-autoscaler/vendor/k8s.io/metrics/pkg/client/external_metrics/fake/fake_client.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/testing"
+	"k8s.io/metrics/pkg/apis/external_metrics/v1beta1"
+	eclient "k8s.io/metrics/pkg/client/external_metrics"
+)
+
+type FakeExternalMetricsClient struct {
+	testing.Fake
+}
+
+func (c *FakeExternalMetricsClient) NamespacedMetrics(namespace string) eclient.MetricsInterface {
+	return &fakeNamespacedMetrics{
+		Fake: c,
+		ns:   namespace,
+	}
+}
+
+type fakeNamespacedMetrics struct {
+	Fake *FakeExternalMetricsClient
+	ns   string
+}
+
+func (m *fakeNamespacedMetrics) List(metricName string, metricSelector labels.Selector) (*v1beta1.ExternalMetricValueList, error) {
+	resource := schema.GroupResource{
+		Group:    v1beta1.SchemeGroupVersion.Group,
+		Resource: metricName,
+	}
+	kind := schema.GroupKind{
+		Group: v1beta1.SchemeGroupVersion.Group,
+		Kind:  "ExternalMetricValue",
+	}
+	action := testing.NewListAction(resource.WithVersion(""), kind.WithVersion(""), m.ns, metav1.ListOptions{LabelSelector: metricSelector.String()})
+	obj, err := m.Fake.
+		Invokes(action, &v1beta1.ExternalMetricValueList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*v1beta1.ExternalMetricValueList), err
+}

--- a/vertical-pod-autoscaler/vendor/modules.txt
+++ b/vertical-pod-autoscaler/vendor/modules.txt
@@ -652,6 +652,7 @@ k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/fake
 k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1
 k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/fake
 k8s.io/metrics/pkg/client/external_metrics
+k8s.io/metrics/pkg/client/external_metrics/fake
 # k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed
 ## explicit; go 1.12
 k8s.io/utils/buffer


### PR DESCRIPTION
An example has been added to `vertical-pod-autoscaler/examples/hamster-external-metrics.yaml` This is a minimal version that reads external metrics every minutes and applies them as recommendations.

Proof that it works:
```
$ k get datadogmetrics,vpa
NAME                                         ACTIVE   VALID   VALUE        REFERENCES                     UPDATE TIME
datadogmetric.datadoghq.com/hamster-cpu      True     True    504.120848   hpa:default/hpa-fake-hamster   2m37s
datadogmetric.datadoghq.com/hamster-memory   True     True    12401664     hpa:default/hpa-fake-hamster   2m37s

NAME                                                   MODE       CPU    MEM    PROVIDED   AGE
verticalpodautoscaler.autoscaling.k8s.io/hamster-vpa   Recreate   580m   50Mi   True       9d
```

```
  Recommendation:
    Container Recommendations:
      Container Name:  hamster
      Lower Bound:
        Cpu:     580m
        Memory:  50Mi
      Target:
        Cpu:     580m
        Memory:  50Mi
      Uncapped Target:
        Cpu:     580m
        Memory:  14261913
      Upper Bound:
        Cpu:     580m
        Memory:  50Mi
```

TODO: Write tests once we agree on the code