### PR TITLE
[local] Add currently draining pod filter into Datadog podlistprocessor

### DIFF
--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -97,7 +97,7 @@ var (
 	cloudConfig             = flag.String("cloud-config", "", "The path to the cloud provider configuration file.  Empty string for no configuration file.")
 	namespace               = flag.String("namespace", "kube-system", "Namespace in which cluster-autoscaler run.")
 	enforceNodeGroupMinSize = flag.Bool("enforce-node-group-min-size", false, "Should CA scale up the node group to the configured min size if needed.")
-	podTemplatesProcessor  = flag.Bool("node-infos-processor-podtemplate", true, "Enable PodTemplate NodeInfoProcessor to consider specific PodTemplate as DaemonSet")
+	podTemplatesProcessor   = flag.Bool("node-infos-processor-podtemplate", true, "Enable PodTemplate NodeInfoProcessor to consider specific PodTemplate as DaemonSet")
 	scaleDownEnabled        = flag.Bool("scale-down-enabled", true, "Should CA scale down the cluster")
 	scaleDownDelayAfterAdd  = flag.Duration("scale-down-delay-after-add", 10*time.Minute,
 		"How long after scale up that scale down evaluation resumes")

--- a/cluster-autoscaler/processors/datadog/pods/processor.go
+++ b/cluster-autoscaler/processors/datadog/pods/processor.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/core/podlistprocessor"
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
 	proc "k8s.io/autoscaler/cluster-autoscaler/processors/pods"
 
@@ -40,6 +41,7 @@ func NewFilteringPodListProcessor() *filteringPodListProcessor {
 			NewTransformDataNodes(),
 		},
 		filters: []proc.PodListProcessor{
+			podlistprocessor.NewCurrentlyDrainedNodesPodListProcessor(),
 			NewFilterOutLongPending(),
 			NewFilterOutSchedulablePodListProcessor(),
 		},


### PR DESCRIPTION
Adds the `CurrentlyDrainedNodesPodListProcessor` into the list of filters supported by the Datadog pods processor. This was introduced upstream in https://github.com/kubernetes/autoscaler/pull/5354/files and should add a small optimization for pods considered unschedulable.

Also fixes an indentation issue from running `./hack/update_gofmt.sh`