### PR TITLE
[WIP] [local] Skip nodegroups that don't have a nodeInfo struct available

### DIFF
--- a/cluster-autoscaler/core/scaleup/resource_manager.go
+++ b/cluster-autoscaler/core/scaleup/resource_manager.go
@@ -214,7 +214,8 @@ func (m *ResourceManager) coresMemoryTotal(ctx *context.AutoscalingContext, node
 
 		nodeInfo, found := nodeInfos[nodeGroup.Id()]
 		if !found {
-			return 0, 0, errors.NewAutoscalerError(errors.CloudProviderError, "No node info for: %s", nodeGroup.Id())
+			klog.Infof("skipping nodegroup %s in total cores/memory calculation", nodeGroup.Id())
+			continue
 		}
 
 		if currentSize > 0 {
@@ -243,7 +244,8 @@ func (m *ResourceManager) customResourcesTotal(ctx *context.AutoscalingContext, 
 
 		nodeInfo, found := nodeInfos[nodeGroup.Id()]
 		if !found {
-			return nil, errors.NewAutoscalerError(errors.CloudProviderError, "No node info for: %s", nodeGroup.Id())
+			klog.Infof("skipping nodegroup %s in total custom resources calculation", nodeGroup.Id())
+			continue
 		}
 
 		if currentSize > 0 {


### PR DESCRIPTION
If a nodeInfo struct is missing for given nodegroup, this would previously block any scaling activity on the cluster because the scale-up routine would always early-exit on the failure from ResourcesLeft. The rest of the scale up routine is equipped to deal with the nodeInfo missing, so not raising an error here should not have any downwind affects in ScaleUp., since
```go
nodeInfo, found := nodeInfos[nodeGroup.Id()]
		if !found {
			klog.Errorf("No node info for: %s", nodeGroup.Id())
			skippedNodeGroups[nodeGroup.Id()] = notReadyReason
			continue
		}
```

The downside is that this makes it possible for the max cores/memory to be exceeded if the ASG in error is non-empty (since it's not included in the calculation).

I also tested this a bit with upstream implementation of the `MixedNodeInfosProvider`:
* pre-hange, if the ASG size containing the 'unknown' instance type is 0, a nodeInfo would fail to be created + all scale-up activities would cease.
* post-change, if the ASG size containing the 'unknown' instance type is 0, the nodeInfo is properly skipped and regular scale-ups can occur
* pre-change, if the ASG size containing the 'unknown' instance type is >0, the `MixedNodeInfosProvider` will be able to synthesize a nodeInfo from an existing node in the cluster
* post-change, if the ASG size containing the 'unknown' instance type is >0, no real affect

So, this issue is somewhat exacerbated for our fork because we _only_ rely on the ASGs to build our templates, but is still a scenario that would be when ng size is 0 (and is definitely possible, like if a new NG is added using a beta instance type that's not covered by `DescribeInstanceTypes` is added with an initial size of 0).

