### PR TITLE
vpa-admisssion-controller: don't panic on pod without any annotations

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/workloads/utils.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/workloads/utils.go
@@ -115,6 +115,9 @@ func PodFromPodTemplateSpec(objectMeta *metav1.ObjectMeta, podTemplateSpec *v1.P
 	}
 	// We also need to propagate the trigger annotation that was likely set on the parent.
 	if annotations.HasVpaTrigger(objectMeta) {
+		if pod.Annotations == nil {
+			pod.Annotations = make(map[string]string)
+		}
 		pod.Annotations[annotations.VpaTriggerLabel] = annotations.VpaTriggerEnabled
 	}
 	if pod.Name == "" {


### PR DESCRIPTION
Fix a panic when the pod spec has no annotation