### PR TITLE
AWS: only look for InstanceRequirements when needed

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -333,7 +333,7 @@ func joinNodeLabelsChoosingUserValuesOverAPIValues(extractedLabels map[string]st
 }
 
 func (m *AwsManager) updateCapacityWithRequirementsOverrides(capacity *apiv1.ResourceList, policy *mixedInstancesPolicy) error {
-	if policy == nil {
+	if policy == nil || len(policy.instanceTypesOverrides) > 0 {
 		return nil
 	}
 


### PR DESCRIPTION
[Cherry-pick of upstream's [#5550](https://github.com/kubernetes/autoscaler/pull/5550)]

In order to support optional InstanceRequirements (attribute-based instance type selection) specifications for ASGs using LaunchTemplates (and not directly specifying those InstanceRequirements inline within the ASG), the cluster-autoscaler's AWS cloud provider was recently improved to look for possible requirements by retrieving LaunchTemplates and their versions, when it builds NodeInfos templates.

With LaunchTemplates, the new NodeInfos generation code flows like so:
```
  GetNodeInfoFromTemplate()
    TemplateNodeInfo()
      buildNodeFromTemplate()
        updateCapacityWithRequirementsOverrides()
          getInstanceRequirementsFromMixedInstancesPolicy()
            // when ASG doesn't specify an instanceRequirementsOverrides inline,
            // we might still find one defined in its current LaunchTemplate, so
            awsService.getLaunchTemplateData()
              DescribeLaunchTemplateVersions()
```

Those LT/versions lookups can't be fetched in batch, and aren't cached, so at very autoscaler loop we're hitting AWS API at O(n) proportionally to the number of ASGs having LaunchTemplates, which is a change compared to cluster-autoscaler 1.24. On clusters having many LTs attached, that can cause a slowdown or trigger throttling from AWS.

But retrieving InstanceRequirements should only be useful when the LT overrides don't already specify an InstanceType, as both are mutually exclusive. The [api reference doc](https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_LaunchTemplateOverrides.html) states:
> If you specify InstanceRequirements, you can't specify InstanceType.

That mutual exclusion [is already leveraged](https://github.com/kubernetes/autoscaler/blob/cluster-autoscaler-1.26.1/cluster-autoscaler/cloudprovider/aws/aws_wrapper.go#L683-L686) by `getInstanceTypesForAsgs`: we don't look for InstanceRequirements when we have a mixed instance policy specifying instance types overrides.

The graph below illustrates the change, on a cluster having 15 ASGs with LaunchTemplates (no InstanceRequirements, patched version rolled at 17:15):

<img src="https://user-images.githubusercontent.com/628273/221949053-4d840a57-cd96-4084-8bb7-b8b4f8830abd.png" width=70% height=70%>

Once patched, the API calls volume remains constant after we attach  2000 ASGs with LaunchTemplates (to a cluster that had 80 ASGs+LCs, hence the DescribeLC calls) and we trigger some upscale and downscale activity:

<img src="https://user-images.githubusercontent.com/628273/222088084-12904bce-c502-449b-ae4e-31fd28aed982.png" width=70% height=70%>

<img src="https://user-images.githubusercontent.com/628273/222088107-98e826ea-ad42-4b23-8e64-02644a1f987c.png" width=70% height=70%>

This change removes the overhead for ASGs with LaunchTemplates not using LT InstanceRequirements (the common case), but doesn't improve the API call rate for not-inline InstanceRequirements cases. As a follow-up, we should also cache resources retrieved by getInstanceRequirementsFromMixedInstancesPolicy to mitigate the API call pressure when using instance requirements definitions in LaunchTemplates rather than inline.

#### What type of PR is this?
/kind bug
/kind regression

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
AWS: save API calls when using LaunchTemplates
```
