### PR TITLE
Optimize termination grace period

### DIFF
--- a/cluster-autoscaler/core/scaledown/actuation/actuator_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/actuator_test.go
@@ -544,7 +544,7 @@ func TestStartDeletion(t *testing.T) {
 					PodEvictionResults: map[string]status.PodEvictionResult{
 						"drain-node-0-pod-0": {Pod: removablePod("drain-node-0-pod-0", "drain-node-0"), Err: cmpopts.AnyError, TimedOut: true},
 						"drain-node-0-pod-1": {Pod: removablePod("drain-node-0-pod-1", "drain-node-0"), Err: cmpopts.AnyError, TimedOut: true},
-						"drain-node-0-pod-2": {Pod: removablePod("drain-node-0-pod-2", "drain-node-0")},
+						"drain-node-0-pod-2": {Pod: removablePod("drain-node-0-pod-2", "drain-node-0"), GracePeriodSeconds: apiv1.DefaultTerminationGracePeriodSeconds},
 					},
 				},
 				"drain-node-1": {ResultType: status.NodeDeleteOk},
@@ -552,9 +552,9 @@ func TestStartDeletion(t *testing.T) {
 					ResultType: status.NodeDeleteErrorFailedToEvictPods,
 					Err:        cmpopts.AnyError,
 					PodEvictionResults: map[string]status.PodEvictionResult{
-						"drain-node-2-pod-0": {Pod: removablePod("drain-node-2-pod-0", "drain-node-2")},
+						"drain-node-2-pod-0": {Pod: removablePod("drain-node-2-pod-0", "drain-node-2"), GracePeriodSeconds: apiv1.DefaultTerminationGracePeriodSeconds},
 						"drain-node-2-pod-1": {Pod: removablePod("drain-node-2-pod-1", "drain-node-2"), Err: cmpopts.AnyError, TimedOut: true},
-						"drain-node-2-pod-2": {Pod: removablePod("drain-node-2-pod-2", "drain-node-2")},
+						"drain-node-2-pod-2": {Pod: removablePod("drain-node-2-pod-2", "drain-node-2"), GracePeriodSeconds: apiv1.DefaultTerminationGracePeriodSeconds},
 					},
 				},
 				"drain-node-3": {ResultType: status.NodeDeleteOk},

--- a/cluster-autoscaler/core/scaledown/status/status.go
+++ b/cluster-autoscaler/core/scaledown/status/status.go
@@ -132,9 +132,10 @@ type NodeDeleteResult struct {
 
 // PodEvictionResult contains the result of an eviction of a pod.
 type PodEvictionResult struct {
-	Pod      *apiv1.Pod
-	TimedOut bool
-	Err      error
+	Pod                *apiv1.Pod
+	TimedOut           bool
+	GracePeriodSeconds int64
+	Err                error
 }
 
 // WasEvictionSuccessful tells if the pod was successfully evicted.


### PR DESCRIPTION
Extends the `PodEvictionResult` to include the amount of time that was allowed for the eviction. This can then be used inside of the `DrainNodeWithPods` to calculate the largest amount of time allotted and only wait that amount of time for all the pods to be gone, instead of always waiting for `--max-graceful-termination-sec`.

For example, if the autoscaler is running with `--max-graceful-termination-sec=3600`, and the pods on the node have the following termination grace periods:
* pod A: 60s
* pod B: unset
* pod C: 20s

Pod B will receive the default termination grace period of 30s. The autoscaler will wait 60s (plus `podEvictionHeadroom`) for the pods to be all gone, because pod A has the longest termination grace period of 60s.


In another example, say the pods have the following termination grace periods: 
* pod A: 7200s
* pod B: unset
* pod C: 20s

This time, pod A's grace period exceeds the max of 3600, so the eviction created by `evictPod` will cap the eviction time at 3600s. Again, pod B gets the default grace period of 30s. Since 3600 > 30 > 20, the drain will wait 3600 (plus `podEvictionHeadroom`) for the pods to be all gone.