### PR TITLE
Check PowerState on provisioning failures

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -161,45 +161,77 @@ func TestIncreaseSize(t *testing.T) {
 }
 
 func TestIncreaseSizeOnVMProvisioningFailed(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+	testCases := map[string]struct {
+		expectInstanceRunning bool
+		isMissingInstanceView bool
+		statuses              []compute.InstanceViewStatus
+	}{
+		"out of resources when no power state exists": {},
+		"out of resources when VM is stopped": {
+			statuses: []compute.InstanceViewStatus{{Code: to.StringPtr(PowerStateStopped)}},
+		},
+		"out of resources when VM reports unknown power state": {
+			statuses: []compute.InstanceViewStatus{{Code: to.StringPtr("PowerState/invalid")}},
+		},
+		"instance running when power state is running": {
+			expectInstanceRunning: true,
+			statuses:              []compute.InstanceViewStatus{{Code: to.StringPtr(PowerStateRunning)}},
+		},
+		"instance running if instance view cannot be retrieved": {
+			expectInstanceRunning: true,
+			isMissingInstanceView: true,
+		},
+	}
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
 
-	manager := newTestAzureManager(t)
-	vmssName := "vmss-failed-upscale"
+			manager := newTestAzureManager(t)
+			vmssName := "vmss-failed-upscale"
 
-	expectedScaleSets := newTestVMSSList(3, "vmss-failed-upscale", "eastus")
-	expectedVMSSVMs := newTestVMSSVMList(3)
-	expectedVMSSVMs[2].ProvisioningState = to.StringPtr(string(compute.ProvisioningStateFailed))
+			expectedScaleSets := newTestVMSSList(3, "vmss-failed-upscale", "eastus")
+			expectedVMSSVMs := newTestVMSSVMList(3)
+			expectedVMSSVMs[2].ProvisioningState = to.StringPtr(string(compute.ProvisioningStateFailed))
+			if !testCase.isMissingInstanceView {
+				expectedVMSSVMs[2].InstanceView = &compute.VirtualMachineScaleSetVMInstanceView{Statuses: &testCase.statuses}
+			}
 
-	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
-	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil)
-	mockVMSSClient.EXPECT().CreateOrUpdateAsync(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).Return(nil, nil)
-	mockVMSSClient.EXPECT().WaitForCreateOrUpdateResult(gomock.Any(), gomock.Any(), manager.config.ResourceGroup).Return(&http.Response{StatusCode: http.StatusOK}, nil).AnyTimes()
-	manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
-	mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
-	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, "vmss-failed-upscale", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
-	manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
-	manager.explicitlyConfigured["vmss-failed-upscale"] = true
-	registered := manager.RegisterNodeGroup(newTestScaleSet(manager, vmssName))
-	assert.True(t, registered)
-	manager.Refresh()
+			mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
+			mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil)
+			mockVMSSClient.EXPECT().CreateOrUpdateAsync(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).Return(nil, nil)
+			mockVMSSClient.EXPECT().WaitForCreateOrUpdateResult(gomock.Any(), gomock.Any(), manager.config.ResourceGroup).Return(&http.Response{StatusCode: http.StatusOK}, nil).AnyTimes()
+			manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+			mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
+			mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, "vmss-failed-upscale", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
+			manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+			manager.explicitlyConfigured["vmss-failed-upscale"] = true
+			registered := manager.RegisterNodeGroup(newTestScaleSet(manager, vmssName))
+			assert.True(t, registered)
+			manager.Refresh()
 
-	provider, err := BuildAzureCloudProvider(manager, nil)
-	assert.NoError(t, err)
+			provider, err := BuildAzureCloudProvider(manager, nil)
+			assert.NoError(t, err)
 
-	scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
-	assert.True(t, ok)
+			scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
+			assert.True(t, ok)
 
-	// Increase size by one, but the new node fails provisioning
-	err = scaleSet.IncreaseSize(1)
-	assert.NoError(t, err)
+			// Increase size by one, but the new node fails provisioning
+			err = scaleSet.IncreaseSize(1)
+			assert.NoError(t, err)
 
-	nodes, err := scaleSet.Nodes()
-	assert.NoError(t, err)
+			nodes, err := scaleSet.Nodes()
+			assert.NoError(t, err)
 
-	assert.Equal(t, 3, len(nodes))
-	assert.Equal(t, cloudprovider.InstanceCreating, nodes[2].Status.State)
-	assert.Equal(t, cloudprovider.OutOfResourcesErrorClass, nodes[2].Status.ErrorInfo.ErrorClass)
+			assert.Equal(t, 3, len(nodes))
+			if testCase.expectInstanceRunning {
+				assert.Equal(t, cloudprovider.InstanceRunning, nodes[2].Status.State)
+			} else {
+				assert.Equal(t, cloudprovider.InstanceCreating, nodes[2].Status.State)
+				assert.Equal(t, cloudprovider.OutOfResourcesErrorClass, nodes[2].Status.ErrorInfo.ErrorClass)
+			}
+		})
+	}
 }
 
 func TestIncreaseSizeOnVMSSUpdating(t *testing.T) {


### PR DESCRIPTION
Fixes an issue where the autoscaler would sometimes scale down in-use azure nodes. This was occurring during large scale ups, where Azure was reporting networking provisioning failures.  
```json
    {
      "code": "ProvisioningState/failed/NetworkingInternalOperationError",
      "level": "Error",
      "displayStatus": "Provisioning failed",
      "message": "An unexpected error occured while processing the network profile of the VM. Please retry later.",
      "time": "2023-05-09T21:02:25.8112918Z"
    },
    {
      "code": "PowerState/running",
      "level": "Info",
      "displayStatus": "VM running"
    }
```

This PR adds support to check the power state if a failed provisioning is reported.  If the VM is running, the instance is reported as running and no OutOfResource error is set. If the VM does not report a power status or has a stopping power status, the OutOfResource error is set.