### PR TITLE
[recommender] ensure that CPU and Mem are fetch on the same time window

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
@@ -23,10 +23,11 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
+
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/annotations"
 	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
-	"k8s.io/klog/v2"
 )
 
 var (


### PR DESCRIPTION
At some point the code is indexing the metrics by timestamp. The problem is that CPU and MEM queries are made in sequence and on big clusters the reply is ~250Mo and takes time to be captured for each query... to point where we have no intersection between the CPU and MEM time window in the response.

For the moment (and this is another problem) the recommender fails if CPU or MEM is missing. I will fix this later. With this PR I just want to make a small step to ensure that we have point for both CPU and MEM at a given common point in time. In a next PR I will refactor the code to handle every resource independently one from the other (user can request reco only for one resource).

This should solve the problem we are having now on `psyduck`. Potentially we will have to reset all checkpoints on that cluster or wait for more than 1 week to activate another workload to ensure that bad history is purged.

Another problem that I need to fix in another PR: when there is a problem with the metric fetch, instead of having no recommendation we end up with the Min reco. This is dangerous we must change this. How: TBD.