### PR TITLE
Safety Margin Modifier Post Processor 

### DIFF
--- a/vertical-pod-autoscaler/FAQ.md
+++ b/vertical-pod-autoscaler/FAQ.md
@@ -184,6 +184,7 @@ Name | Type | Description | Default
 `memory-histogram-decay-half-life` | Duration | The amount of time it takes a historical memory usage sample to lose half of its weight. In other words, a fresh usage sample is twice as 'important' as one with age equal to the half life period. | model.DefaultMemoryHistogramDecayHalfLife
 `cpu-histogram-decay-half-life` | Duration | The amount of time it takes a historical CPU usage sample to lose half of its weight. | model.DefaultCPUHistogramDecayHalfLife
 `cpu-integer-post-processor-enabled` | Bool | Enable the CPU integer recommendation post processor | false
+`safety-margin-modifier-post-processor-enabled` | Bool | Enable the safety margin modifier recommendation post processor | false
 
 ### What are the parameters to VPA updater?
 

--- a/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/README.md
@@ -339,13 +339,13 @@ this parameter is unique and applies to all VPAs under the recommender. Some app
 This configuration consists in an annotation on your VPA object for each impacted container. The annotation format is the following:
 
 ```
-vpa-post-processor.kubernetes.io/{containerName}_safetyMarginModifier={"function": "Linear", parameters: [1.10]}
+vpa-post-processor.kubernetes.io/{containerName}_safetyMarginModifier={"cpu": {"function": "Linear", parameters: [1.10]}, "memory": {"function": "Linear", parameters: [1.30]}}
 ```
 
-You can also specify a different modifier per resource:
+You can also specify a wildcard modifier:
 
 ```
-vpa-post-processor.kubernetes.io/{containerName}_safetyMarginModifier={"cpu": {"function": "Linear", parameters: [1.10]}, "memory": {"function": "Linear", parameters: [1.30]} }
+vpa-post-processor.kubernetes.io/{containerName}_safetyMarginModifier={"*": {"function": "Linear", parameters: [1.10]}}
 ```
 
 Note: before applying the custom margin modifier, the post processor reverts the default safety margin applied to the recommendation.

--- a/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/README.md
@@ -359,6 +359,13 @@ Name | Parameters | Formula | Description
 | Log | [factor] | recommendation \* (1 + factor \* log10(recommendation)) | Add to the recommendation a value proportional to the logarithm of the base recommendation
 | Exponential | [exponent, factor] | recommendation \* (1 + factor \* recommendation ^ exponent) | Add to the recommendation a value proportional to a power of the base recommendation (note: most of the time, you will want an exponent lower than 1)
 
+Note: as some modifiers' output depend on the scale of the resoure Quantity, here are the units used by the modifiers:
+
+Resource Name | Unit
+|-|-|
+| CPU | millicores
+| Memory | Bytes
+
 
 # Known limitations
 

--- a/vertical-pod-autoscaler/pkg/recommender/routines/safety_margin_modifier_post_processor.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/safety_margin_modifier_post_processor.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routines
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
+	"k8s.io/klog/v2"
+)
+
+type SafetyMarginModifierPostProcessor struct {
+	DefaultSafetyMarginFactor float64
+}
+
+type modifierFunction int64
+
+const (
+	undefined modifierFunction = iota
+	linear
+	log
+	affine
+	exponential
+)
+
+type safetyMarginFunction struct {
+	Function   modifierFunction
+	Parameters []float64
+}
+
+type safetyMarginModifier map[v1.ResourceName]safetyMarginFunction
+
+const (
+	vpaPostProcessorSafetyMarginModifierSuffix = "_safetyMarginModifier"
+)
+
+var _ RecommendationPostProcessor = &SafetyMarginModifierPostProcessor{}
+
+// Process applies the Resource Ratio post-processing to the recommendation.
+func (r *SafetyMarginModifierPostProcessor) Process(vpa *model.Vpa, recommendation *vpa_types.RecommendedPodResources, policy *vpa_types.PodResourcePolicy) *vpa_types.RecommendedPodResources {
+	updatedRecommendation := recommendation.DeepCopy()
+	modifiers := readSafetyMarginModifierFromVPAAnnotations(vpa)
+
+	for _, containerRec := range updatedRecommendation.ContainerRecommendations {
+		modifier, found := modifiers[containerRec.ContainerName]
+
+		if !found {
+			continue
+		}
+		klog.Infof("Apply safety marging modifier on container %s in vpa %s/%s", containerRec.ContainerName, vpa.ID.Namespace, vpa.ID.VpaName)
+
+		r.applyModifier(vpa, containerRec.ContainerName, containerRec.LowerBound, modifier)
+		r.applyModifier(vpa, containerRec.ContainerName, containerRec.Target, modifier)
+		r.applyModifier(vpa, containerRec.ContainerName, containerRec.UpperBound, modifier)
+		r.applyModifier(vpa, containerRec.ContainerName, containerRec.UncappedTarget, modifier)
+	}
+
+	return updatedRecommendation
+}
+
+func (r *SafetyMarginModifierPostProcessor) applyModifier(vpa *model.Vpa, name string, containerRec v1.ResourceList, modifier safetyMarginModifier) {
+	for resourceName, rec := range containerRec {
+		resourceModifier, found := modifier[resourceName]
+		if !found {
+			continue
+		}
+
+		var newRec float64
+
+		// CPU requests are expressed in milli cores, which impacts the modification brough by
+		// the Log and Exponential modifiers. If the resource is CPU, scale it by 1000.
+		recCopy := rec.DeepCopy()
+		if resourceName == v1.ResourceCPU {
+			recCopy.SetScaled(rec.MilliValue(), 0)
+		}
+
+		switch resourceModifier.Function {
+		case linear:
+			if len(resourceModifier.Parameters) != 1 {
+				klog.Errorf("Skipping %s safety margin modifier in vpa %s/%s: linear modifier requires 1 parameter, %d given", resourceName, name, vpa.ID.Namespace, vpa.ID.VpaName, len(resourceModifier.Parameters))
+				continue
+			}
+			newRec = linearModifier(recCopy, r.DefaultSafetyMarginFactor, resourceModifier.Parameters[0])
+		case affine:
+			if len(resourceModifier.Parameters) != 2 {
+				klog.Errorf("Skipping %s safety margin modifier in vpa %s/%s: affine modifier requires 2 parameters, %d given", resourceName, name, vpa.ID.Namespace, vpa.ID.VpaName, len(resourceModifier.Parameters))
+				continue
+			}
+			newRec = affineModifier(recCopy, r.DefaultSafetyMarginFactor, resourceModifier.Parameters[0], resourceModifier.Parameters[1])
+		case log:
+			if len(resourceModifier.Parameters) != 1 {
+				klog.Errorf("Skipping %s safety margin modifier in vpa %s/%s: log modifier requires 1 parameter, %d given", resourceName, name, vpa.ID.Namespace, vpa.ID.VpaName, len(resourceModifier.Parameters))
+				continue
+			}
+			newRec = logModifier(recCopy, r.DefaultSafetyMarginFactor, resourceModifier.Parameters[0])
+		case exponential:
+			if len(resourceModifier.Parameters) != 2 {
+				klog.Errorf("Skipping %s safety margin modifier in vpa %s/%s: exponential modifier requires 2 parameters, %d given", resourceName, name, vpa.ID.Namespace, vpa.ID.VpaName, len(resourceModifier.Parameters))
+				continue
+			}
+			newRec = exponentialModifier(recCopy, r.DefaultSafetyMarginFactor, resourceModifier.Parameters[0], resourceModifier.Parameters[1])
+		case undefined:
+			continue
+		default:
+			klog.Errorf("Skipping %s safety margin modifier in vpa %s/%s: specified modifier is not valid", name, vpa.ID.Namespace, vpa.ID.VpaName)
+		}
+
+		if resourceName == v1.ResourceCPU {
+			containerRec[resourceName] = *resource.NewMilliQuantity(int64(newRec), resource.DecimalSI)
+		} else {
+			containerRec[resourceName] = *resource.NewQuantity(int64(newRec), resource.DecimalSI)
+		}
+	}
+}
+
+// Undo default safety margin before applying a custom linear safety margin (a * baseRec)
+func linearModifier(rec resource.Quantity, defaultSafetyMargin, slope float64) float64 {
+	return float64(rec.Value()) / defaultSafetyMargin * slope
+}
+
+// Undo default safety margin before applying a custom affine safety margin (a * baseRec + b)
+func affineModifier(rec resource.Quantity, defaultSafetyMargin, constant, slope float64) float64 {
+	return float64(rec.Value())/defaultSafetyMargin*slope + constant
+}
+
+// Undo default safety margin before applying a custom logarithmic safety margin (baseRec + a * log10(baseRec))
+func logModifier(rec resource.Quantity, defaultSafetyMargin, factor float64) float64 {
+	rawRec := float64(rec.Value()) / defaultSafetyMargin
+	return rawRec + math.Log10(rawRec)*factor
+}
+
+// Undo default safety margin before applying a custom exponential safety margin (baseRec + a * baseRec^b)
+func exponentialModifier(rec resource.Quantity, defaultSafetyMargin, exponent, factor float64) float64 {
+	rawRec := float64(rec.Value()) / defaultSafetyMargin
+	return rawRec + math.Pow(rawRec, exponent)*factor
+}
+
+func readSafetyMarginModifierFromVPAAnnotations(vpa *model.Vpa) map[string]safetyMarginModifier {
+	modifiers := map[string]safetyMarginModifier{}
+	for key, value := range vpa.Annotations {
+		containerName := extractContainerName(key, vpaPostProcessorPrefix, vpaPostProcessorSafetyMarginModifierSuffix)
+		if containerName == "" {
+			continue
+		}
+
+		safetyMarginModifier := safetyMarginModifier{}
+		safetyMarginFunction := safetyMarginFunction{}
+		if err := json.Unmarshal([]byte(value), &safetyMarginModifier); err != nil {
+			if err := json.Unmarshal([]byte(value), &safetyMarginFunction); err != nil {
+				klog.Errorf("Skipping safety margin modifier definition '%s' for container '%s' in vpa %s/%s due to bad format, error:%#v", value, containerName, vpa.ID.Namespace, vpa.ID.VpaName, err)
+				continue
+			}
+			safetyMarginModifier[v1.ResourceCPU] = safetyMarginFunction
+			safetyMarginModifier[v1.ResourceMemory] = safetyMarginFunction
+		}
+		modifiers[containerName] = safetyMarginModifier
+	}
+	return modifiers
+}
+
+func (f modifierFunction) String() string {
+	switch f {
+	case linear:
+		return "linear"
+	case log:
+		return "log"
+	case affine:
+		return "affine"
+	case exponential:
+		return "exponential"
+	default:
+		return "undefined"
+	}
+}
+
+func (f modifierFunction) MarshalJSON() ([]byte, error) {
+	return json.Marshal(f.String())
+}
+
+func (f *modifierFunction) UnmarshalJSON(data []byte) (err error) {
+	var functionString string
+	if err := json.Unmarshal(data, &functionString); err != nil {
+		return err
+	}
+	functionString = strings.ToLower(functionString)
+
+	switch functionString {
+	case "linear":
+		*f = linear
+	case "log":
+		*f = log
+	case "affine":
+		*f = affine
+	case "exponential":
+		*f = exponential
+	default:
+		*f = undefined
+		return fmt.Errorf("cannot unmarshall string into ModifierFunction: %s is not a valid function name", functionString)
+	}
+	return nil
+}

--- a/vertical-pod-autoscaler/pkg/recommender/routines/safety_margin_modifier_post_processor_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/safety_margin_modifier_post_processor_test.go
@@ -1,0 +1,327 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routines
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
+)
+
+func TestSafetyMarginModifier_Process(t *testing.T) {
+	tests := []struct {
+		name           string
+		vpa            *model.Vpa
+		recommendation *vpa_types.RecommendedPodResources
+		want           *vpa_types.RecommendedPodResources
+	}{
+		{
+			name: "No containers match",
+			vpa: &model.Vpa{Annotations: map[string]string{
+				vpaPostProcessorPrefix + "container-other" + vpaPostProcessorSafetyMarginModifierSuffix: "{}",
+			}},
+			recommendation: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("8.6", "200Mi").GetContainerResources(),
+					test.Recommendation().WithContainer("container2").WithTarget("8.2", "300Mi").GetContainerResources(),
+				},
+			},
+			want: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("8.6", "200Mi").GetContainerResources(),
+					test.Recommendation().WithContainer("container2").WithTarget("8.2", "300Mi").GetContainerResources(),
+				},
+			},
+		},
+		{
+			name: "Malformed annotation",
+			vpa: &model.Vpa{Annotations: map[string]string{
+				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"functio\": \"Linear\"}",
+			}},
+			recommendation: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("1", "200Mi").GetContainerResources(),
+				},
+			},
+			want: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("1", "200Mi").GetContainerResources(),
+				},
+			},
+		},
+		{
+			name: "Invalid Function",
+			vpa: &model.Vpa{Annotations: map[string]string{
+				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"function\": \"Sqrt\", \"parameters\": [1.2]}",
+			}},
+			recommendation: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("1", "200Mi").GetContainerResources(),
+				},
+			},
+			want: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("1", "200Mi").GetContainerResources(),
+				},
+			},
+		},
+		{
+			name: "2 containers, 1 matching only",
+			vpa: &model.Vpa{Annotations: map[string]string{
+				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"function\": \"Linear\", \"parameters\": [1.20]}",
+			}},
+			recommendation: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("1", "200Mi").GetContainerResources(),
+					test.Recommendation().WithContainer("container2").WithTarget("2", "300Mi").GetContainerResources(),
+				},
+			},
+			want: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("1.2", "240Mi").GetContainerResources(),
+					test.Recommendation().WithContainer("container2").WithTarget("2", "300Mi").GetContainerResources(),
+				},
+			},
+		},
+		{
+			name: "2 containers, 2 matching",
+			vpa: &model.Vpa{Annotations: map[string]string{
+				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"function\": \"Linear\", \"parameters\": [1.20]}",
+				vpaPostProcessorPrefix + "container2" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"function\": \"Linear\", \"parameters\": [1.10]}",
+			}},
+			recommendation: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("1", "200Mi").GetContainerResources(),
+					test.Recommendation().WithContainer("container2").WithTarget("2", "300Mi").GetContainerResources(),
+				},
+			},
+			want: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("1.2", "240Mi").GetContainerResources(),
+					test.Recommendation().WithContainer("container2").WithTarget("2.2", "330Mi").GetContainerResources(),
+				},
+			},
+		},
+		{
+			name: "Case Incensitive",
+			vpa: &model.Vpa{Annotations: map[string]string{
+				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"function\": \"lIneAR\", \"parameters\": [1.20]}",
+			}},
+			recommendation: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("1", "200Mi").GetContainerResources(),
+				},
+			},
+			want: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("1.2", "240Mi").GetContainerResources(),
+				},
+			},
+		},
+		{
+			name: "Different CPU and Memory modifiers",
+			vpa: &model.Vpa{Annotations: map[string]string{
+				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"cpu\":{\"function\": \"Linear\", \"parameters\": [1.20]}, \"memory\":{\"function\": \"Linear\", \"parameters\": [1.1]}}",
+			}},
+			recommendation: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("1", "200Mi").GetContainerResources(),
+				},
+			},
+			want: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("1.2", "220Mi").GetContainerResources(),
+				},
+			},
+		},
+		{
+			name: "CPU only modifier",
+			vpa: &model.Vpa{Annotations: map[string]string{
+				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"cpu\":{\"function\": \"Linear\", \"parameters\": [1.20]}}",
+			}},
+			recommendation: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("1", "200Mi").GetContainerResources(),
+				},
+			},
+			want: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("1.2", "200Mi").GetContainerResources(),
+				},
+			},
+		},
+		{
+			name: "Linear Modifier",
+			vpa: &model.Vpa{Annotations: map[string]string{
+				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"function\": \"Linear\", \"parameters\": [1.20]}",
+			}},
+			recommendation: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("1", "200Mi").GetContainerResources(),
+				},
+			},
+			want: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("1.2", "240Mi").GetContainerResources(),
+				},
+			},
+		},
+		{
+			name: "Linear Modifier: Wrong number of parameters",
+			vpa: &model.Vpa{Annotations: map[string]string{
+				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"function\": \"Linear\", \"parameters\": []}",
+			}},
+			recommendation: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("1", "200Mi").GetContainerResources(),
+				},
+			},
+			want: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("1", "200Mi").GetContainerResources(),
+				},
+			},
+		},
+		{
+			name: "Affine Modifier",
+			vpa: &model.Vpa{Annotations: map[string]string{
+				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"cpu\": {\"function\": \"Affine\", \"parameters\": [100, 1.1]}, \"memory\": {\"function\": \"Affine\", \"parameters\": [104857600, 1.1]}}",
+			}},
+			recommendation: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("1", "200Mi").GetContainerResources(),
+				},
+			},
+			want: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("1.2", "320Mi").GetContainerResources(),
+				},
+			},
+		},
+		{
+			name: "Affine Modifier: Wrong number of parameters",
+			vpa: &model.Vpa{Annotations: map[string]string{
+				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"function\": \"Affine\", \"parameters\": [100, 1, 2000]}",
+			}},
+			recommendation: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("1", "200Mi").GetContainerResources(),
+				},
+			},
+			want: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("1", "200Mi").GetContainerResources(),
+				},
+			},
+		},
+		{
+			name: "Log Modifier",
+			vpa: &model.Vpa{Annotations: map[string]string{
+				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"function\": \"Log\", \"parameters\": [100]}",
+			}},
+			recommendation: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("1", "200Mi").GetContainerResources(),
+				},
+			},
+			want: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("1.3", "209716032").GetContainerResources(),
+				},
+			},
+		},
+		{
+			name: "Log Modifier: Wrong number of parameters",
+			vpa: &model.Vpa{Annotations: map[string]string{
+				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"function\": \"Log\", \"parameters\": [100, 1]}",
+			}},
+			recommendation: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("1", "200Mi").GetContainerResources(),
+				},
+			},
+			want: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("1", "200Mi").GetContainerResources(),
+				},
+			},
+		},
+		{
+			name: "Exponential Modifier",
+			vpa: &model.Vpa{Annotations: map[string]string{
+				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"function\": \"Exponential\", \"parameters\": [0.5, 10]}",
+			}},
+			recommendation: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("1", "200Mi").GetContainerResources(),
+				},
+			},
+			want: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("1316m", "209860015").GetContainerResources(),
+				},
+			},
+		},
+		{
+			name: "Exponential Modifier: Wrong number of parameters",
+			vpa: &model.Vpa{Annotations: map[string]string{
+				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"function\": \"Exponential\", \"parameters\": [0.5]}",
+			}},
+			recommendation: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("1", "200Mi").GetContainerResources(),
+				},
+			},
+			want: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("1", "200Mi").GetContainerResources(),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := SafetyMarginModifierPostProcessor{DefaultSafetyMarginFactor: 1}
+			got := s.Process(tt.vpa, tt.recommendation, nil)
+			assert.True(t, equalRecommendedPodResources(tt.want, got), "Process(%v, %v, nil)", tt.vpa, tt.recommendation)
+		})
+	}
+}
+
+func TestSafetyMarginModifier_IgnoreDefaultSafetyMargin(t *testing.T) {
+	vpa := &model.Vpa{Annotations: map[string]string{
+		vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"function\": \"Linear\", \"parameters\": [1.5]}",
+	}}
+	recommendation := &vpa_types.RecommendedPodResources{
+		ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+			test.Recommendation().WithContainer("container1").WithTarget("1.2", "240Mi").GetContainerResources(),
+		},
+	}
+	want := &vpa_types.RecommendedPodResources{
+		ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+			test.Recommendation().WithContainer("container1").WithTarget("1.5", "300Mi").GetContainerResources(),
+		},
+	}
+	t.Run("Ignore default safety margin", func(t *testing.T) {
+		s := SafetyMarginModifierPostProcessor{DefaultSafetyMarginFactor: 1.2}
+		got := s.Process(vpa, recommendation, nil)
+		assert.True(t, equalRecommendedPodResources(want, got), "Process(%v, %v, nil)", vpa, recommendation)
+	})
+}

--- a/vertical-pod-autoscaler/pkg/recommender/routines/safety_margin_modifier_post_processor_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/safety_margin_modifier_post_processor_test.go
@@ -69,7 +69,7 @@ func TestSafetyMarginModifier_Process(t *testing.T) {
 		{
 			name: "Invalid Function",
 			vpa: &model.Vpa{Annotations: map[string]string{
-				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"function\": \"Sqrt\", \"parameters\": [1.2]}",
+				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"*\":{\"function\": \"Sqrt\", \"parameters\": [1.2]}}",
 			}},
 			recommendation: &vpa_types.RecommendedPodResources{
 				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
@@ -85,7 +85,7 @@ func TestSafetyMarginModifier_Process(t *testing.T) {
 		{
 			name: "2 containers, 1 matching only",
 			vpa: &model.Vpa{Annotations: map[string]string{
-				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"function\": \"Linear\", \"parameters\": [1.20]}",
+				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"*\":{\"function\": \"Linear\", \"parameters\": [1.20]}}",
 			}},
 			recommendation: &vpa_types.RecommendedPodResources{
 				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
@@ -103,8 +103,8 @@ func TestSafetyMarginModifier_Process(t *testing.T) {
 		{
 			name: "2 containers, 2 matching",
 			vpa: &model.Vpa{Annotations: map[string]string{
-				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"function\": \"Linear\", \"parameters\": [1.20]}",
-				vpaPostProcessorPrefix + "container2" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"function\": \"Linear\", \"parameters\": [1.10]}",
+				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"*\":{\"function\": \"Linear\", \"parameters\": [1.20]}}",
+				vpaPostProcessorPrefix + "container2" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"*\":{\"function\": \"Linear\", \"parameters\": [1.10]}}",
 			}},
 			recommendation: &vpa_types.RecommendedPodResources{
 				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
@@ -122,7 +122,7 @@ func TestSafetyMarginModifier_Process(t *testing.T) {
 		{
 			name: "Case Incensitive",
 			vpa: &model.Vpa{Annotations: map[string]string{
-				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"function\": \"lIneAR\", \"parameters\": [1.20]}",
+				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"*\":{\"function\": \"lIneAR\", \"parameters\": [1.20]}}",
 			}},
 			recommendation: &vpa_types.RecommendedPodResources{
 				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
@@ -170,7 +170,7 @@ func TestSafetyMarginModifier_Process(t *testing.T) {
 		{
 			name: "Linear Modifier",
 			vpa: &model.Vpa{Annotations: map[string]string{
-				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"function\": \"Linear\", \"parameters\": [1.20]}",
+				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"*\":{\"function\": \"Linear\", \"parameters\": [1.20]}}",
 			}},
 			recommendation: &vpa_types.RecommendedPodResources{
 				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
@@ -186,7 +186,7 @@ func TestSafetyMarginModifier_Process(t *testing.T) {
 		{
 			name: "Linear Modifier: Wrong number of parameters",
 			vpa: &model.Vpa{Annotations: map[string]string{
-				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"function\": \"Linear\", \"parameters\": []}",
+				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"*\":{\"function\": \"Linear\", \"parameters\": []}}",
 			}},
 			recommendation: &vpa_types.RecommendedPodResources{
 				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
@@ -218,7 +218,7 @@ func TestSafetyMarginModifier_Process(t *testing.T) {
 		{
 			name: "Affine Modifier: Wrong number of parameters",
 			vpa: &model.Vpa{Annotations: map[string]string{
-				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"function\": \"Affine\", \"parameters\": [100, 1, 2000]}",
+				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"*\":{\"function\": \"Affine\", \"parameters\": [100, 1, 2000]}}",
 			}},
 			recommendation: &vpa_types.RecommendedPodResources{
 				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
@@ -234,7 +234,7 @@ func TestSafetyMarginModifier_Process(t *testing.T) {
 		{
 			name: "Log Modifier",
 			vpa: &model.Vpa{Annotations: map[string]string{
-				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"function\": \"Log\", \"parameters\": [100]}",
+				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"*\":{\"function\": \"Log\", \"parameters\": [100]}}",
 			}},
 			recommendation: &vpa_types.RecommendedPodResources{
 				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
@@ -250,7 +250,7 @@ func TestSafetyMarginModifier_Process(t *testing.T) {
 		{
 			name: "Log Modifier: Wrong number of parameters",
 			vpa: &model.Vpa{Annotations: map[string]string{
-				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"function\": \"Log\", \"parameters\": [100, 1]}",
+				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"*\":{\"function\": \"Log\", \"parameters\": [100, 1]}}",
 			}},
 			recommendation: &vpa_types.RecommendedPodResources{
 				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
@@ -266,7 +266,7 @@ func TestSafetyMarginModifier_Process(t *testing.T) {
 		{
 			name: "Exponential Modifier",
 			vpa: &model.Vpa{Annotations: map[string]string{
-				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"function\": \"Exponential\", \"parameters\": [0.5, 10]}",
+				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"*\":{\"function\": \"Exponential\", \"parameters\": [0.5, 10]}}",
 			}},
 			recommendation: &vpa_types.RecommendedPodResources{
 				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
@@ -282,7 +282,7 @@ func TestSafetyMarginModifier_Process(t *testing.T) {
 		{
 			name: "Exponential Modifier: Wrong number of parameters",
 			vpa: &model.Vpa{Annotations: map[string]string{
-				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"function\": \"Exponential\", \"parameters\": [0.5]}",
+				vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"*\":{\"function\": \"Exponential\", \"parameters\": [0.5]}}",
 			}},
 			recommendation: &vpa_types.RecommendedPodResources{
 				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
@@ -307,7 +307,7 @@ func TestSafetyMarginModifier_Process(t *testing.T) {
 
 func TestSafetyMarginModifier_IgnoreDefaultSafetyMargin(t *testing.T) {
 	vpa := &model.Vpa{Annotations: map[string]string{
-		vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"function\": \"Linear\", \"parameters\": [1.5]}",
+		vpaPostProcessorPrefix + "container1" + vpaPostProcessorSafetyMarginModifierSuffix: "{\"*\":{\"function\": \"Linear\", \"parameters\": [1.5]}}",
 	}}
 	recommendation := &vpa_types.RecommendedPodResources{
 		ContainerRecommendations: []vpa_types.RecommendedContainerResources{


### PR DESCRIPTION
#### Which component this PR applies to?

vertical-pod-autoscaler

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

By default, the VPA recommender adds a safety margin of 15% to its CPU and Memory recommendation which can be adjusted by passing the `recommendation-margin-fraction` flag to the invocation command. However,
this parameter is unique and applies to all VPAs under the recommender. Some application would benefit from a different safety margin. Moreover, one may want to pass the recommendation through a custom function
(e.g.: affine, log).
When enabled, this post-processor reads the `vpa-post-processor.kubernetes.io/{containerName}_safetyMarginModifier` annotation of VPA objects and apply the given custom safety marging modifier post processor

Available functions:

Name | Parameters | Formula | Description
|-|-|-|-|
| Linear | [slope] | slope \* recommendation | Similar to the default safety margin. Multiplies the recommendation by a safety factor (e.g: 15% margin means a factor of 1.15)
| Affine | [constant, slope] | constant + slope \* recommendation | Similar to the default safety margin but also adds a constant to the recommendation
| Log | [factor] | recommendation \* (1 + factor \* log10(recommendation)) | Add to the recommendation a value proportional to the logarithm of the base recommendation
| Exponential | [exponent, factor] | recommendation \* (1 + factor \* recommendation ^ exponent) | Add to the recommendation a value proportional to a power of the base recommendation (note: most of the time, you will want an exponent lower than 1)


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


```docs
[Usage]: https://github.com/DataDog/autoscaler/blob/409e2cac8e470bbc6bd659df9ac256e5fcc84487/vertical-pod-autoscaler/README.md#custom-safety-margin-per-vpa
```
