### PR TITLE
[local] new syntax to define ratio inside the annotation

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -133,7 +133,7 @@ func main() {
 		postProcessors = append(postProcessors, &routines.IntegerCPUPostProcessor{})
 	}
 	if *postProcessorMaintainResourceRatio {
-		postProcessors = append(postProcessors, &routines.ReplicaRestrictionsPostProcessor{ControllerFetcher: controllerFetcher})
+		postProcessors = append(postProcessors, &routines.ResourceRatioRecommendationPostProcessor{ControllerFetcher: controllerFetcher})
 	}
 	if *postProcessorReplicaRestrictions {
 		postProcessors = append(postProcessors, &routines.ReplicaRestrictionsPostProcessor{ControllerFetcher: controllerFetcher})

--- a/vertical-pod-autoscaler/pkg/recommender/routines/resource_ratio_post_processor.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/resource_ratio_post_processor.go
@@ -91,7 +91,7 @@ func readResourceRatioFromVPAAnnotations(vpa *model.Vpa) map[string]resourceRati
 			continue
 		}
 
-		ratioDef := map[string]RatioDefinition{} // the key is the primary resource on whic h the ratio is applied
+		ratioDef := map[string]RatioDefinition{} // the key is the primary resource on which the ratio is applied
 
 		if err := json.Unmarshal([]byte(value), &ratioDef); err != nil {
 			klog.Errorf("Skipping ratio definition '%s' for container '%s' in vpa %s/%s due to bad format, error:%#v", value, containerName, vpa.ID.Namespace, vpa.ID.VpaName, err)
@@ -199,7 +199,7 @@ func applyMaintainRatioVPAPolicy(recommendation apiv1.ResourceList, ratiosPolici
 
 	for _, ratioConstraint := range maintainedRatiosCalculationOrdered {
 		var ratio float64
-		// if the ration is define explicitely, use the defined value, else use the original ratio of the podSpec
+		// if the ration is defined explicitly, use the defined value, else use the original ratio of the podSpec
 		if ratioConstraint.ratio != nil {
 			ratio = *ratioConstraint.ratio
 		} else {

--- a/vertical-pod-autoscaler/pkg/recommender/routines/resource_ratio_post_processor.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/resource_ratio_post_processor.go
@@ -70,6 +70,7 @@ func (r *ResourceRatioRecommendationPostProcessor) Process(vpa *model.Vpa, recom
 	return updatedRecommendation
 }
 
+// RatioDefinition is the system used in the annotation map[string]RatioDefinition{} to configure the post-processor
 type RatioDefinition struct {
 	Resource string   `json:"resource"`
 	Ratio    *float64 `json:"ratio"`
@@ -199,7 +200,7 @@ func applyMaintainRatioVPAPolicy(recommendation apiv1.ResourceList, ratiosPolici
 
 	for _, ratioConstraint := range maintainedRatiosCalculationOrdered {
 		var ratio float64
-		// if the ration is defined explicitly, use the defined value, else use the original ratio of the podSpec
+		// if the ratio is defined explicitly, use the defined value, else use the original ratio of the podSpec
 		if ratioConstraint.ratio != nil {
 			ratio = *ratioConstraint.ratio
 		} else {

--- a/vertical-pod-autoscaler/pkg/recommender/routines/resource_ratio_post_processor_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/resource_ratio_post_processor_test.go
@@ -238,7 +238,7 @@ func Test_resourceRatioRecommendationProcessor_Apply(t *testing.T) {
 			name: "cpu to mem",
 			args: args{
 				podRecommendation: podRecommendation,
-				ratioPolicies:     map[string]resourceRatioList{"ctr-name": resourceRatioList{{original: "cpu", target: "memory"}}},
+				ratioPolicies:     map[string]resourceRatioList{"ctr-name": {{original: "cpu", target: "memory"}}},
 				pod:               pod13,
 			},
 			wantReco: podRecommendationExpected13,


### PR DESCRIPTION
Change the api for the ratio post-processor:
`{"cpu":{"resource":"memory","ratio":15000000}}`
if the ratio is not specified, the one in the podTemplate is used:
`{"cpu":{"resource":"memory"}}`