### PR TITLE
[local] Eager and longer long-pending quarantines

### DIFF
--- a/cluster-autoscaler/processors/datadog/pods/filter_long_pending_test.go
+++ b/cluster-autoscaler/processors/datadog/pods/filter_long_pending_test.go
@@ -146,7 +146,7 @@ func TestBuildDeadline(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			now = func() time.Time { return time.Time{} }
-			maxExpected := now().Add(3 * test.coolDownDelay.Abs())
+			maxExpected := now().Add(time.Duration(delayFactor+1) * test.coolDownDelay.Abs())
 			result := buildDeadline(test.attempts, test.coolDownDelay)
 			if result.Before(now()) || result.After(maxExpected) {
 				t.Errorf("buildDeadline(%v, %v) = %v, should be in [%v-%v] range",


### PR DESCRIPTION
Initial values were meant to be conservative and proven in the wild.

This was successful in the sense that no false positive delays were detected. But less so in the sense that we missed opportunities to protect overwhelmed autoscaler soon enough and for long enough. This change makes it quarantine pods earlier, and for a longer time (also securing more opportunities to get out of scale down cool down periods).

I don't want to change code for future fine tuning, and I'd rather avoid conflicting with command line flags during rebases (that processor isn't available in upstream autoscaler), so changed to support passing values from env.

#### Which component this PR applies to?

<!--
Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) this PR applies to?
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
