### PR TITLE
[vertical-pod-autoscaler] Add AllowedResourceFilter to restrict which recommendations can be applied

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/main.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/main.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -69,6 +70,7 @@ var (
 	registerWebhook    = flag.Bool("register-webhook", true, "If set to true, admission webhook object will be created on start up to register with the API server.")
 	registerByURL      = flag.Bool("register-by-url", false, "If set to true, admission webhook will be registered by URL (webhookAddress:webhookPort) instead of by service name")
 	vpaObjectNamespace = flag.String("vpa-object-namespace", apiv1.NamespaceAll, "Namespace to search for VPA objects. Empty means all namespaces will be used.")
+	allowedResources   = flag.String("allowed-resources", strings.Join([]string{string(apiv1.ResourceCPU), string(apiv1.ResourceMemory)}, ","), "Comma-separated list of resources that can be applied from a VPA.")
 )
 
 func main() {
@@ -96,7 +98,14 @@ func main() {
 		klog.Errorf("Failed to create limitRangeCalculator, falling back to not checking limits. Error message: %s", err)
 		limitRangeCalculator = limitrange.NewNoopLimitsCalculator()
 	}
-	recommendationProvider := recommendation.NewProvider(limitRangeCalculator, vpa_api_util.NewCappingRecommendationProcessor(limitRangeCalculator))
+
+	var allowedResourcesNames []apiv1.ResourceName
+	for _, resourceName := range strings.Split(*allowedResources, ",") {
+		if resourceName != "" {
+			allowedResourcesNames = append(allowedResourcesNames, apiv1.ResourceName(resourceName))
+		}
+	}
+	recommendationProvider := recommendation.NewProvider(limitRangeCalculator, vpa_api_util.NewDefaultRecommendationProcessor(limitRangeCalculator, allowedResourcesNames))
 	vpaMatcher := vpa.NewMatcher(vpaLister, targetSelectorFetcher)
 
 	hostname, err := os.Hostname()

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider_test.go
@@ -116,10 +116,11 @@ func TestUpdateResourceRequests(t *testing.T) {
 		name              string
 		pod               *apiv1.Pod
 		vpa               *vpa_types.VerticalPodAutoscaler
+		allowedResources  []apiv1.ResourceName
 		expectedAction    bool
 		expectedError     error
-		expectedMem       resource.Quantity
-		expectedCPU       resource.Quantity
+		expectedMem       *resource.Quantity
+		expectedCPU       *resource.Quantity
 		expectedCPULimit  *resource.Quantity
 		expectedMemLimit  *resource.Quantity
 		limitRange        *apiv1.LimitRangeItem
@@ -127,74 +128,82 @@ func TestUpdateResourceRequests(t *testing.T) {
 		annotations       vpa_api_util.ContainerToAnnotationsMap
 	}{
 		{
-			name:           "uninitialized pod",
-			pod:            uninitialized,
-			vpa:            vpa,
-			expectedAction: true,
-			expectedMem:    resource.MustParse("200Mi"),
-			expectedCPU:    resource.MustParse("2"),
+			name:             "uninitialized pod",
+			pod:              uninitialized,
+			vpa:              vpa,
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceCPU, apiv1.ResourceMemory},
+			expectedAction:   true,
+			expectedMem:      mustParseResourcePointer("200Mi"),
+			expectedCPU:      mustParseResourcePointer("2"),
 		},
 		{
-			name:           "target below min",
-			pod:            uninitialized,
-			vpa:            targetBelowMinVPA,
-			expectedAction: true,
-			expectedMem:    resource.MustParse("300Mi"), // MinMemory is expected to be used
-			expectedCPU:    resource.MustParse("4"),     // MinCpu is expected to be used
+			name:             "target below min",
+			pod:              uninitialized,
+			vpa:              targetBelowMinVPA,
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceCPU, apiv1.ResourceMemory},
+			expectedAction:   true,
+			expectedMem:      mustParseResourcePointer("300Mi"), // MinMemory is expected to be used
+			expectedCPU:      mustParseResourcePointer("4"),     // MinCpu is expected to be used
 			annotations: vpa_api_util.ContainerToAnnotationsMap{
 				containerName: []string{"cpu capped to minAllowed", "memory capped to minAllowed"},
 			},
 		},
 		{
-			name:           "target above max",
-			pod:            uninitialized,
-			vpa:            targetAboveMaxVPA,
-			expectedAction: true,
-			expectedMem:    resource.MustParse("1Gi"), // MaxMemory is expected to be used
-			expectedCPU:    resource.MustParse("5"),   // MaxCpu is expected to be used
+			name:             "target above max",
+			pod:              uninitialized,
+			vpa:              targetAboveMaxVPA,
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceCPU, apiv1.ResourceMemory},
+			expectedAction:   true,
+			expectedMem:      mustParseResourcePointer("1Gi"), // MaxMemory is expected to be used
+			expectedCPU:      mustParseResourcePointer("5"),   // MaxCpu is expected to be used
 			annotations: vpa_api_util.ContainerToAnnotationsMap{
 				containerName: []string{"cpu capped to maxAllowed", "memory capped to maxAllowed"},
 			},
 		},
 		{
-			name:           "initialized pod",
-			pod:            initialized,
-			vpa:            vpa,
-			expectedAction: true,
-			expectedMem:    resource.MustParse("200Mi"),
-			expectedCPU:    resource.MustParse("2"),
+			name:             "initialized pod",
+			pod:              initialized,
+			vpa:              vpa,
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceCPU, apiv1.ResourceMemory},
+			expectedAction:   true,
+			expectedMem:      mustParseResourcePointer("200Mi"),
+			expectedCPU:      mustParseResourcePointer("2"),
 		},
 		{
-			name:           "high memory",
-			pod:            initialized,
-			vpa:            vpaWithHighMemory,
-			expectedAction: true,
-			expectedMem:    resource.MustParse("1000Mi"),
-			expectedCPU:    resource.MustParse("2"),
+			name:             "high memory",
+			pod:              initialized,
+			vpa:              vpaWithHighMemory,
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceCPU, apiv1.ResourceMemory},
+			expectedAction:   true,
+			expectedMem:      mustParseResourcePointer("1000Mi"),
+			expectedCPU:      mustParseResourcePointer("2"),
 		},
 		{
-			name:           "empty recommendation",
-			pod:            initialized,
-			vpa:            vpaWithEmptyRecommendation,
-			expectedAction: true,
-			expectedMem:    resource.MustParse("0"),
-			expectedCPU:    resource.MustParse("0"),
+			name:             "empty recommendation",
+			pod:              initialized,
+			vpa:              vpaWithEmptyRecommendation,
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceCPU, apiv1.ResourceMemory},
+			expectedAction:   true,
+			expectedMem:      nil,
+			expectedCPU:      nil,
 		},
 		{
-			name:           "nil recommendation",
-			pod:            initialized,
-			vpa:            vpaWithNilRecommendation,
-			expectedAction: true,
-			expectedMem:    resource.MustParse("0"),
-			expectedCPU:    resource.MustParse("0"),
+			name:             "nil recommendation",
+			pod:              initialized,
+			vpa:              vpaWithNilRecommendation,
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceCPU, apiv1.ResourceMemory},
+			expectedAction:   true,
+			expectedMem:      nil,
+			expectedCPU:      nil,
 		},
 		{
 			name:             "guaranteed resources",
 			pod:              limitsMatchRequestsPod,
 			vpa:              vpa,
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceCPU, apiv1.ResourceMemory},
 			expectedAction:   true,
-			expectedMem:      resource.MustParse("200Mi"),
-			expectedCPU:      resource.MustParse("2"),
+			expectedMem:      mustParseResourcePointer("200Mi"),
+			expectedCPU:      mustParseResourcePointer("2"),
 			expectedCPULimit: mustParseResourcePointer("2"),
 			expectedMemLimit: mustParseResourcePointer("200Mi"),
 		},
@@ -202,9 +211,10 @@ func TestUpdateResourceRequests(t *testing.T) {
 			name:             "guaranteed resources - no request",
 			pod:              limitsNoRequestsPod,
 			vpa:              vpa,
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceCPU, apiv1.ResourceMemory},
 			expectedAction:   true,
-			expectedMem:      resource.MustParse("200Mi"),
-			expectedCPU:      resource.MustParse("2"),
+			expectedMem:      mustParseResourcePointer("200Mi"),
+			expectedCPU:      mustParseResourcePointer("2"),
 			expectedCPULimit: mustParseResourcePointer("2"),
 			expectedMemLimit: mustParseResourcePointer("200Mi"),
 		},
@@ -212,9 +222,10 @@ func TestUpdateResourceRequests(t *testing.T) {
 			name:             "proportional limit - as default",
 			pod:              podWithDoubleLimit,
 			vpa:              vpa,
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceCPU, apiv1.ResourceMemory},
 			expectedAction:   true,
-			expectedCPU:      resource.MustParse("2"),
-			expectedMem:      resource.MustParse("200Mi"),
+			expectedCPU:      mustParseResourcePointer("2"),
+			expectedMem:      mustParseResourcePointer("200Mi"),
 			expectedCPULimit: mustParseResourcePointer("4"),
 			expectedMemLimit: mustParseResourcePointer("400Mi"),
 		},
@@ -222,27 +233,30 @@ func TestUpdateResourceRequests(t *testing.T) {
 			name:             "proportional limit - set explicit",
 			pod:              podWithDoubleLimit,
 			vpa:              resourceRequestsAndLimitsVPA,
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceCPU, apiv1.ResourceMemory},
 			expectedAction:   true,
-			expectedCPU:      resource.MustParse("2"),
-			expectedMem:      resource.MustParse("200Mi"),
+			expectedCPU:      mustParseResourcePointer("2"),
+			expectedMem:      mustParseResourcePointer("200Mi"),
 			expectedCPULimit: mustParseResourcePointer("4"),
 			expectedMemLimit: mustParseResourcePointer("400Mi"),
 		},
 		{
-			name:           "disabled limit scaling",
-			pod:            podWithDoubleLimit,
-			vpa:            resourceRequestsOnlyVPA,
-			expectedAction: true,
-			expectedCPU:    resource.MustParse("2"),
-			expectedMem:    resource.MustParse("200Mi"),
+			name:             "disabled limit scaling",
+			pod:              podWithDoubleLimit,
+			vpa:              resourceRequestsOnlyVPA,
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceCPU, apiv1.ResourceMemory},
+			expectedAction:   true,
+			expectedCPU:      mustParseResourcePointer("2"),
+			expectedMem:      mustParseResourcePointer("200Mi"),
 		},
 		{
-			name:           "disabled limit scaling - requests capped at limit",
-			pod:            podWithDoubleLimit,
-			vpa:            resourceRequestsOnlyVPAHighTarget,
-			expectedAction: true,
-			expectedCPU:    resource.MustParse("2"),
-			expectedMem:    resource.MustParse("200Mi"),
+			name:             "disabled limit scaling - requests capped at limit",
+			pod:              podWithDoubleLimit,
+			vpa:              resourceRequestsOnlyVPAHighTarget,
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceCPU, apiv1.ResourceMemory},
+			expectedAction:   true,
+			expectedCPU:      mustParseResourcePointer("2"),
+			expectedMem:      mustParseResourcePointer("200Mi"),
 			annotations: vpa_api_util.ContainerToAnnotationsMap{
 				containerName: []string{
 					"cpu capped to container limit",
@@ -254,9 +268,10 @@ func TestUpdateResourceRequests(t *testing.T) {
 			name:             "limit over int64",
 			pod:              podWithTenfoldLimit,
 			vpa:              vpaWithExabyteRecommendation,
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceCPU, apiv1.ResourceMemory},
 			expectedAction:   true,
-			expectedCPU:      resource.MustParse("1Ei"),
-			expectedMem:      resource.MustParse("1Ei"),
+			expectedCPU:      mustParseResourcePointer("1Ei"),
+			expectedMem:      mustParseResourcePointer("1Ei"),
 			expectedCPULimit: resource.NewMilliQuantity(math.MaxInt64, resource.DecimalExponent),
 			expectedMemLimit: resource.NewQuantity(math.MaxInt64, resource.DecimalExponent),
 			annotations: vpa_api_util.ContainerToAnnotationsMap{
@@ -270,6 +285,7 @@ func TestUpdateResourceRequests(t *testing.T) {
 			name:              "limit range calculation error",
 			pod:               initialized,
 			vpa:               vpa,
+			allowedResources:  []apiv1.ResourceName{apiv1.ResourceCPU, apiv1.ResourceMemory},
 			limitRangeCalcErr: fmt.Errorf("oh no"),
 			expectedAction:    false,
 			expectedError:     fmt.Errorf("error getting containerLimitRange: oh no"),
@@ -278,9 +294,10 @@ func TestUpdateResourceRequests(t *testing.T) {
 			name:             "proportional limit from default",
 			pod:              initialized,
 			vpa:              vpa,
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceCPU, apiv1.ResourceMemory},
 			expectedAction:   true,
-			expectedCPU:      resource.MustParse("2"),
-			expectedMem:      resource.MustParse("200Mi"),
+			expectedCPU:      mustParseResourcePointer("2"),
+			expectedMem:      mustParseResourcePointer("200Mi"),
 			expectedCPULimit: mustParseResourcePointer("2"),
 			expectedMemLimit: mustParseResourcePointer("200Mi"),
 			limitRange: &apiv1.LimitRangeItem{
@@ -291,12 +308,28 @@ func TestUpdateResourceRequests(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:             "memory recommendation filtered out",
+			pod:              initialized,
+			vpa:              vpa,
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceCPU},
+			expectedAction:   true,
+			expectedCPU:      mustParseResourcePointer("2"),
+		},
+		{
+			name:             "cpu recommendation filtered out",
+			pod:              initialized,
+			vpa:              vpa,
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceMemory},
+			expectedAction:   true,
+			expectedMem:      mustParseResourcePointer("200Mi"),
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			recommendationProvider := &recommendationProvider{
-				recommendationProcessor: vpa_api_util.NewCappingRecommendationProcessor(limitrange.NewNoopLimitsCalculator()),
+				recommendationProcessor: vpa_api_util.NewDefaultRecommendationProcessor(limitrange.NewNoopLimitsCalculator(), tc.allowedResources),
 				limitsRangeCalculator: &fakeLimitRangeCalculator{
 					containerLimitRange: tc.limitRange,
 					containerErr:        tc.limitRangeCalcErr,
@@ -314,11 +347,23 @@ func TestUpdateResourceRequests(t *testing.T) {
 				_, foundEmpty := resources[0].Requests[""]
 				assert.Equal(t, foundEmpty, false, "empty resourceKey have not been purged")
 
-				cpuRequest := resources[0].Requests[apiv1.ResourceCPU]
-				assert.Equal(t, tc.expectedCPU.Value(), cpuRequest.Value(), "cpu request doesn't match")
+				cpuRequest, cpuRequestPresent := resources[0].Requests[apiv1.ResourceCPU]
+				if tc.expectedCPU == nil {
+					assert.False(t, cpuRequestPresent, "expected no cpu request, got %s", cpuRequest.String())
+				} else {
+					if assert.True(t, cpuRequestPresent, "expected cpu request, but it's missing") {
+						assert.Equal(t, tc.expectedCPU.Value(), cpuRequest.Value(), "cpu request doesn't match")
+					}
+				}
 
-				memoryRequest := resources[0].Requests[apiv1.ResourceMemory]
-				assert.Equal(t, tc.expectedMem.Value(), memoryRequest.Value(), "memory request doesn't match")
+				memoryRequest, memoryRequestPresent := resources[0].Requests[apiv1.ResourceMemory]
+				if tc.expectedMem == nil {
+					assert.False(t, memoryRequestPresent, "expected no mem request, got %s", memoryRequest.String())
+				} else {
+					if assert.True(t, memoryRequestPresent, "expected memory request, but it's missing") {
+						assert.Equal(t, tc.expectedMem.Value(), memoryRequest.Value(), "memory request doesn't match")
+					}
+				}
 
 				cpuLimit, cpuLimitPresent := resources[0].Limits[apiv1.ResourceCPU]
 				if tc.expectedCPULimit == nil {

--- a/vertical-pod-autoscaler/pkg/utils/vpa/allowed_resource_filter.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/allowed_resource_filter.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+)
+
+// NewAllowedResourceFilter is a RecommendationProcessor that restricts which resources from a
+// VPA's recommendation can actually be applied on a container
+func NewAllowedResourceFilter(allowedResources []corev1.ResourceName) RecommendationProcessor {
+	return &allowedResourceFilter{
+		allowedResources: allowedResources,
+	}
+}
+
+type allowedResourceFilter struct {
+	allowedResources []corev1.ResourceName
+}
+
+// Apply chains calls to underlying RecommendationProcessors in order provided on object construction
+func (p *allowedResourceFilter) Apply(podRecommendation *vpa_types.RecommendedPodResources,
+	policy *vpa_types.PodResourcePolicy,
+	conditions []vpa_types.VerticalPodAutoscalerCondition,
+	pod *corev1.Pod) (*vpa_types.RecommendedPodResources, ContainerToAnnotationsMap, error) {
+	recommendation := podRecommendation
+	accumulatedContainerToAnnotationsMap := ContainerToAnnotationsMap{}
+
+	for i, containerRecommendation := range recommendation.ContainerRecommendations {
+		recommendation.ContainerRecommendations[i] = filterAllowedContainerResources(containerRecommendation, p.allowedResources)
+	}
+
+	return recommendation, accumulatedContainerToAnnotationsMap, nil
+}
+
+func filterAllowedContainerResources(recommendation vpa_types.RecommendedContainerResources, allowedResources []corev1.ResourceName) vpa_types.RecommendedContainerResources {
+	recommendation.Target = filterResourceList(recommendation.Target, allowedResources)
+	recommendation.LowerBound = filterResourceList(recommendation.LowerBound, allowedResources)
+	recommendation.UpperBound = filterResourceList(recommendation.UpperBound, allowedResources)
+	recommendation.UncappedTarget = filterResourceList(recommendation.UncappedTarget, allowedResources)
+	return recommendation
+}
+
+func filterResourceList(resourceList corev1.ResourceList, allowedResources []corev1.ResourceName) corev1.ResourceList {
+	filteredResourceList := corev1.ResourceList{}
+	for resourceName, resourceValue := range resourceList {
+		if containsResource(allowedResources, resourceName) {
+			filteredResourceList[resourceName] = resourceValue
+		}
+	}
+	return filteredResourceList
+}
+
+func containsResource(resourceNames []corev1.ResourceName, target corev1.ResourceName) bool {
+	for _, resourceName := range resourceNames {
+		if target == resourceName {
+			return true
+		}
+	}
+	return false
+}

--- a/vertical-pod-autoscaler/pkg/utils/vpa/allowed_resource_filter_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/allowed_resource_filter_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"testing"
+)
+
+func TestAllowedResourceFilter(t *testing.T) {
+	tests := []struct {
+		name                   string
+		allowedResources       []apiv1.ResourceName
+		recommendation         vpa_types.RecommendedPodResources
+		expectedRecommendation vpa_types.RecommendedPodResources
+	}{
+		{
+			name: "empty allowed resources produces no recommended values",
+			recommendation: vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					{
+						ContainerName: "container-1",
+						Target: apiv1.ResourceList{
+							apiv1.ResourceCPU:    resource.MustParse("1500m"),
+							apiv1.ResourceMemory: resource.MustParse("64Mi"),
+						},
+						LowerBound: apiv1.ResourceList{
+							apiv1.ResourceCPU:    resource.MustParse("1200m"),
+							apiv1.ResourceMemory: resource.MustParse("48Mi"),
+						},
+						UpperBound: apiv1.ResourceList{
+							apiv1.ResourceCPU:    resource.MustParse("1800m"),
+							apiv1.ResourceMemory: resource.MustParse("80Mi"),
+						},
+						UncappedTarget: apiv1.ResourceList{
+							apiv1.ResourceCPU:    resource.MustParse("2500m"),
+							apiv1.ResourceMemory: resource.MustParse("128Mi"),
+						},
+					},
+					{
+						ContainerName: "container-2",
+						Target: apiv1.ResourceList{
+							apiv1.ResourceCPU:    resource.MustParse("3000m"),
+							apiv1.ResourceMemory: resource.MustParse("128Mi"),
+						},
+						LowerBound: apiv1.ResourceList{
+							apiv1.ResourceCPU:    resource.MustParse("2400m"),
+							apiv1.ResourceMemory: resource.MustParse("96Mi"),
+						},
+						UpperBound: apiv1.ResourceList{
+							apiv1.ResourceCPU:    resource.MustParse("3600m"),
+							apiv1.ResourceMemory: resource.MustParse("160Mi"),
+						},
+						UncappedTarget: apiv1.ResourceList{
+							apiv1.ResourceCPU:    resource.MustParse("50000m"),
+							apiv1.ResourceMemory: resource.MustParse("256Mi"),
+						},
+					},
+				},
+			},
+			expectedRecommendation: vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					{
+						ContainerName:  "container-1",
+						Target:         apiv1.ResourceList{},
+						LowerBound:     apiv1.ResourceList{},
+						UpperBound:     apiv1.ResourceList{},
+						UncappedTarget: apiv1.ResourceList{},
+					},
+					{
+						ContainerName:  "container-2",
+						Target:         apiv1.ResourceList{},
+						LowerBound:     apiv1.ResourceList{},
+						UpperBound:     apiv1.ResourceList{},
+						UncappedTarget: apiv1.ResourceList{},
+					},
+				},
+			},
+		},
+		{
+			name:             "filter partial set of resources",
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceCPU, apiv1.ResourceMemory},
+			recommendation: vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					{
+						ContainerName: "container-1",
+						Target: apiv1.ResourceList{
+							apiv1.ResourceCPU:                            resource.MustParse("1500m"),
+							apiv1.ResourceMemory:                         resource.MustParse("128Mi"),
+							apiv1.ResourceEphemeralStorage:               resource.MustParse("10Gi"),
+							apiv1.ResourceName("some.extended/resource"): resource.MustParse("4"),
+						},
+						LowerBound: apiv1.ResourceList{
+							apiv1.ResourceCPU:                            resource.MustParse("1200m"),
+							apiv1.ResourceMemory:                         resource.MustParse("96Mi"),
+							apiv1.ResourceEphemeralStorage:               resource.MustParse("8Gi"),
+							apiv1.ResourceName("some.extended/resource"): resource.MustParse("2"),
+						},
+						UpperBound: apiv1.ResourceList{
+							apiv1.ResourceCPU:                            resource.MustParse("1800m"),
+							apiv1.ResourceMemory:                         resource.MustParse("256Mi"),
+							apiv1.ResourceEphemeralStorage:               resource.MustParse("12Gi"),
+							apiv1.ResourceName("some.extended/resource"): resource.MustParse("6"),
+						},
+						UncappedTarget: apiv1.ResourceList{
+							apiv1.ResourceCPU:                            resource.MustParse("2500m"),
+							apiv1.ResourceMemory:                         resource.MustParse("1Gi"),
+							apiv1.ResourceEphemeralStorage:               resource.MustParse("20Gi"),
+							apiv1.ResourceName("some.extended/resource"): resource.MustParse("8"),
+						},
+					},
+				},
+			},
+			expectedRecommendation: vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					{
+						ContainerName: "container-1",
+						Target: apiv1.ResourceList{
+							apiv1.ResourceCPU:    resource.MustParse("1500m"),
+							apiv1.ResourceMemory: resource.MustParse("128Mi"),
+						},
+						LowerBound: apiv1.ResourceList{
+							apiv1.ResourceCPU:    resource.MustParse("1200m"),
+							apiv1.ResourceMemory: resource.MustParse("96Mi"),
+						},
+						UpperBound: apiv1.ResourceList{
+							apiv1.ResourceCPU:    resource.MustParse("1800m"),
+							apiv1.ResourceMemory: resource.MustParse("256Mi"),
+						},
+						UncappedTarget: apiv1.ResourceList{
+							apiv1.ResourceCPU:    resource.MustParse("2500m"),
+							apiv1.ResourceMemory: resource.MustParse("1Gi"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			processor := NewAllowedResourceFilter(tc.allowedResources)
+			processedRecommendation, _, err := processor.Apply(&tc.recommendation, nil, nil, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedRecommendation, *processedRecommendation)
+		})
+	}
+}


### PR DESCRIPTION
Adds a new recommendation post-processor that restricts which recommended resources can actually be applied to a pod. This is useful for preventing new/experimental recommendations from immediately being applied, as well as preventing intermediate values without a backing extended resource from being applied.

It's implemented as a RecommendationProcessor; I'm using the existing (but previously unused) SequentialProcessor to hook in the Capping processor (which was previously the only RecommendationProcessor used) and this new AllowedResourceFilter.

It's gated by a command line option `--allowed-resources` in both the updater and admission controller. By default, this should be no change from the current behavior where only cpu/memory are applied.