### PR TITLE
Explicitly initialize AWS instance status object

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -354,7 +354,7 @@ func (ng *AwsNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 	instances := make([]cloudprovider.Instance, len(asgNodes))
 
 	for i, asgNode := range asgNodes {
-		var status *cloudprovider.InstanceStatus
+		status := &cloudprovider.InstanceStatus{}
 		instanceStatusString, err := ng.awsManager.GetInstanceStatus(asgNode)
 		if err != nil {
 			klog.V(4).Infof("Could not get instance status, continuing anyways: %v", err)


### PR DESCRIPTION
Fixes an issue where on AWS, a long-unregistered node would completely block scale-ups.

e5bc070c8c58a7d12e4c62c08fc4eda17aa7ee5b changed the behavior of `getNotRegisteredNodes` to filter out nodes that were not expected to register with 
```go
func expectedToRegister(instance cloudprovider.Instance) bool {
	return instance.Status != nil && instance.Status.State != cloudprovider.InstanceDeleting && instance.Status.ErrorInfo == nil
}
```


However, the `instance.Status` field is **optional**, and not all cloud providers set this. Notably, AWS did not initialize this unless a 'placeholder' instance was set, such that in normal circumstances, AWS instances will have `nil` as a status. This meant that `expectedToRegister` would return false, and the host would not have an entry appended to the `notRegistered` slice of nodes.

This explicitly initializes AWS's instanceStatus struct, which means that for a long unregistered node, `expectedToRegister` should now properly return `true`, and the normal mechanisms for clearing a long unregistered node can operate on it.