### PR TITLE
Bugfix: Check recommendation is non-nil before iterating

### DIFF
--- a/vertical-pod-autoscaler/pkg/utils/vpa/allowed_resource_filter.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/allowed_resource_filter.go
@@ -38,14 +38,19 @@ func (p *allowedResourceFilter) Apply(podRecommendation *vpa_types.RecommendedPo
 	policy *vpa_types.PodResourcePolicy,
 	conditions []vpa_types.VerticalPodAutoscalerCondition,
 	pod *corev1.Pod) (*vpa_types.RecommendedPodResources, ContainerToAnnotationsMap, error) {
-	recommendation := podRecommendation
-	accumulatedContainerToAnnotationsMap := ContainerToAnnotationsMap{}
 
-	for i, containerRecommendation := range recommendation.ContainerRecommendations {
-		recommendation.ContainerRecommendations[i] = filterAllowedContainerResources(containerRecommendation, p.allowedResources)
+	if podRecommendation == nil || policy == nil {
+		// If there is no recommendation or no policies have been defined then no recommendation can be computed.
+		return podRecommendation, nil, nil
 	}
 
-	return recommendation, accumulatedContainerToAnnotationsMap, nil
+	accumulatedContainerToAnnotationsMap := ContainerToAnnotationsMap{}
+
+	for i, containerRecommendation := range podRecommendation.ContainerRecommendations {
+		podRecommendation.ContainerRecommendations[i] = filterAllowedContainerResources(containerRecommendation, p.allowedResources)
+	}
+
+	return podRecommendation, accumulatedContainerToAnnotationsMap, nil
 }
 
 func filterAllowedContainerResources(recommendation vpa_types.RecommendedContainerResources, allowedResources []corev1.ResourceName) vpa_types.RecommendedContainerResources {

--- a/vertical-pod-autoscaler/pkg/utils/vpa/allowed_resource_filter_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/allowed_resource_filter_test.go
@@ -157,7 +157,7 @@ func TestAllowedResourceFilter(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			processor := NewAllowedResourceFilter(tc.allowedResources)
-			processedRecommendation, _, err := processor.Apply(&tc.recommendation, nil, nil, nil)
+			processedRecommendation, _, err := processor.Apply(&tc.recommendation, &vpa_types.PodResourcePolicy{}, nil, nil)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedRecommendation, *processedRecommendation)
 		})


### PR DESCRIPTION
Fixes an issue where a nil recommendation would attempt to be iterated over. This takes similar logic from the capping processor.