### PR TITLE
[bugfix] Remove erroneous policy check

### DIFF
--- a/vertical-pod-autoscaler/pkg/utils/vpa/allowed_resource_filter.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/allowed_resource_filter.go
@@ -39,9 +39,9 @@ func (p *allowedResourceFilter) Apply(podRecommendation *vpa_types.RecommendedPo
 	conditions []vpa_types.VerticalPodAutoscalerCondition,
 	pod *corev1.Pod) (*vpa_types.RecommendedPodResources, ContainerToAnnotationsMap, error) {
 
-	if podRecommendation == nil || policy == nil {
-		// If there is no recommendation or no policies have been defined then no recommendation can be computed.
-		return podRecommendation, nil, nil
+	if podRecommendation == nil {
+		// If there is no recommendation then no filtered recommendation can be computed.
+		return nil, nil, nil
 	}
 
 	accumulatedContainerToAnnotationsMap := ContainerToAnnotationsMap{}


### PR DESCRIPTION
Fixes an issue introduced in https://github.com/DataDog/autoscaler/pull/105; I originally added an additional nil check for the `resourcePolicy` field from the VPA, based on the similar checks in the capping processor.  However, this resulted in a case where the filtering processor would have a recommendation set but no policy, and exit without removing the fields that needed to be filtered.

This removes that erroneous check.
