### PR TITLE
[local] Fix CI for master-1.12 branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: '>=1.20.0'
+          go-version: '1.20.14'
 
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
That branch (and really, cluster-autoscaler-1.28.x) won't pass CI anymore as its `GO111MODULE=auto` will choke with golang >= 1.21, yet the CI specified `'>=1.20.0'`, so it broke when a newer version of `actions/setup-go` was provided.