### PR TITLE
Fix CI for master-1.12 branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: '>=1.20.0'
+          go-version: '1.20.14'
 
       - uses: actions/checkout@v2
         with:

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -325,7 +325,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		GpuTotal:                         parsedGpuTotal,
 		NodeGroups:                       *nodeGroupsFlag,
 		EnforceNodeGroupMinSize:          *enforceNodeGroupMinSize,
-		NodeInfosProcessorPodTemplates:     *podTemplatesProcessor,
+		NodeInfosProcessorPodTemplates:   *podTemplatesProcessor,
 		ScaleDownDelayAfterAdd:           *scaleDownDelayAfterAdd,
 		ScaleDownDelayAfterDelete:        *scaleDownDelayAfterDelete,
 		ScaleDownDelayAfterFailure:       *scaleDownDelayAfterFailure,


### PR DESCRIPTION
That branch (and really, cluster-autoscaler-1.28.x) won't pass CI
anymore as its `GO111MODULE=auto` will break with golang >= 1.21,
yet the CI specified `'>=1.20.0'`, so it broke when a newer version
of `actions/setup-go` was provided.

Also fix a gofmt issue on that breaks on newer versions.