### PR TITLE
Track previous deletions when cache is refreshed

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -545,14 +545,14 @@ func (scaleSet *ScaleSet) Nodes() ([]cloudprovider.Instance, error) {
 	klog.V(4).Infof("VMSS: orchestration Mode %s", orchestrationMode)
 
 	if orchestrationMode == compute.Uniform {
-		err := scaleSet.buildScaleSetCache(lastRefresh)
+		err := scaleSet.buildScaleSetCache(lastRefresh, scaleSet.instanceCache)
 		if err != nil {
 			return nil, err
 		}
 
 	} else if orchestrationMode == compute.Flexible {
 		if scaleSet.manager.config.EnableVmssFlex {
-			err := scaleSet.buildScaleSetCacheForFlex(lastRefresh)
+			err := scaleSet.buildScaleSetCacheForFlex(lastRefresh, scaleSet.instanceCache)
 			if err != nil {
 				return nil, err
 			}
@@ -568,7 +568,7 @@ func (scaleSet *ScaleSet) Nodes() ([]cloudprovider.Instance, error) {
 	return scaleSet.instanceCache, nil
 }
 
-func (scaleSet *ScaleSet) buildScaleSetCache(lastRefresh time.Time) error {
+func (scaleSet *ScaleSet) buildScaleSetCache(lastRefresh time.Time, lastInstanceCacheState []cloudprovider.Instance) error {
 	vms, rerr := scaleSet.GetScaleSetVms()
 	if rerr != nil {
 		if isAzureRequestsThrottled(rerr) {
@@ -580,13 +580,13 @@ func (scaleSet *ScaleSet) buildScaleSetCache(lastRefresh time.Time) error {
 		return rerr.Error()
 	}
 
-	scaleSet.instanceCache = buildInstanceCache(vms)
+	scaleSet.instanceCache = buildInstanceCache(vms, lastInstanceCacheState)
 	scaleSet.lastInstanceRefresh = lastRefresh
 
 	return nil
 }
 
-func (scaleSet *ScaleSet) buildScaleSetCacheForFlex(lastRefresh time.Time) error {
+func (scaleSet *ScaleSet) buildScaleSetCacheForFlex(lastRefresh time.Time, lastInstanceCacheState []cloudprovider.Instance) error {
 	vms, rerr := scaleSet.GetFlexibleScaleSetVms()
 	if rerr != nil {
 		if isAzureRequestsThrottled(rerr) {
@@ -598,7 +598,7 @@ func (scaleSet *ScaleSet) buildScaleSetCacheForFlex(lastRefresh time.Time) error
 		return rerr.Error()
 	}
 
-	scaleSet.instanceCache = buildInstanceCache(vms)
+	scaleSet.instanceCache = buildInstanceCache(vms, lastInstanceCacheState)
 	scaleSet.lastInstanceRefresh = lastRefresh
 
 	return nil
@@ -606,8 +606,17 @@ func (scaleSet *ScaleSet) buildScaleSetCacheForFlex(lastRefresh time.Time) error
 
 // Note that the GetScaleSetVms() results is not used directly because for the List endpoint,
 // their resource ID format is not consistent with Get endpoint
-func buildInstanceCache(vmList interface{}) []cloudprovider.Instance {
+func buildInstanceCache(vmList interface{}, lastInstanceCacheState []cloudprovider.Instance) []cloudprovider.Instance {
 	instances := []cloudprovider.Instance{}
+
+	// Find the instances that are already being deleted, so that status is not
+	// lost when the cache is rebuilt
+	var instancesBeingDeleted []cloudprovider.Instance
+	for _, instance := range lastInstanceCacheState {
+		if instance.Status != nil && instance.Status.State == cloudprovider.InstanceDeleting {
+			instancesBeingDeleted = append(instancesBeingDeleted, instance)
+		}
+	}
 
 	switch vms := vmList.(type) {
 	case []compute.VirtualMachineScaleSetVM:
@@ -616,7 +625,7 @@ func buildInstanceCache(vmList interface{}) []cloudprovider.Instance {
 			if vm.InstanceView != nil && vm.InstanceView.Statuses != nil {
 				powerState = vmPowerStateFromStatuses(*vm.InstanceView.Statuses)
 			}
-			addInstanceToCache(&instances, vm.ID, vm.ProvisioningState, powerState)
+			addInstanceToCache(&instances, instancesBeingDeleted, vm.ID, vm.ProvisioningState, powerState)
 		}
 	case []compute.VirtualMachine:
 		for _, vm := range vms {
@@ -624,14 +633,14 @@ func buildInstanceCache(vmList interface{}) []cloudprovider.Instance {
 			if vm.InstanceView != nil && vm.InstanceView.Statuses != nil {
 				powerState = vmPowerStateFromStatuses(*vm.InstanceView.Statuses)
 			}
-			addInstanceToCache(&instances, vm.ID, vm.ProvisioningState, powerState)
+			addInstanceToCache(&instances, instancesBeingDeleted, vm.ID, vm.ProvisioningState, powerState)
 		}
 	}
 
 	return instances
 }
 
-func addInstanceToCache(instances *[]cloudprovider.Instance, id *string, provisioningState *string, powerState string) {
+func addInstanceToCache(instances *[]cloudprovider.Instance, instancesBeingDeleted []cloudprovider.Instance, id *string, provisioningState *string, powerState string) {
 	// The resource ID is empty string, which indicates the instance may be in deleting state.
 	if len(*id) == 0 {
 		return
@@ -644,10 +653,18 @@ func addInstanceToCache(instances *[]cloudprovider.Instance, id *string, provisi
 		return
 	}
 
-	*instances = append(*instances, cloudprovider.Instance{
-		Id:     "azure://" + resourceID,
-		Status: instanceStatusFromProvisioningStateAndPowerState(resourceID, provisioningState, powerState),
-	})
+	// Ensure that instances that had the deleting state prior to the last cache refresh
+	// still maintain the deleting state
+	newId := "azure://" + resourceID
+	newStatus := instanceStatusFromProvisioningStateAndPowerState(resourceID, provisioningState, powerState)
+	for _, instance := range instancesBeingDeleted {
+		if newId == instance.Id {
+			newStatus = &cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeleting}
+			klog.V(4).Infof("VM %s was previously identified as undergoing deletion, persisting InstanceDeleting state", resourceID)
+			break
+		}
+	}
+	*instances = append(*instances, cloudprovider.Instance{Id: newId, Status: newStatus})
 }
 
 func (scaleSet *ScaleSet) getInstanceByProviderID(providerID string) (cloudprovider.Instance, bool) {


### PR DESCRIPTION
Fixes an issue where deletion tracking would sometimes lose track of an instance that had already had a deletion submitted, which would lead to too many scale downs. The general flow that would cause this is:
* Deletion requested for a VM, which sets the state as InstanceDeleting and decrements size
  - The API call is slow and does not immediately transition the instance to actually deleting
* A rebuild of the instance cache occurs, which sets the instance state to its 'real' value (e.g. Running)
* Deletion is requested again; size is decremented _again_ and state is set as InstanceDeleting again
  - This repeats until the API calls actually go through
 
This would cause issues if multiple deletes were triggered and then upscale was triggered while the current size was vastly out of sync with the real size of the VMSS. E.g. if the VMSS had 12 instances, and two were stuck in this deletion case, multiple runs of the loop could slowly reduce the in-memory size to 0 instances, such that a scale up would be treated as 0->1, which would actually scale down many instances in the VMSS (12->1)

This is achieved by tracking the last state of the cache on refreshes; now if an instance was previously deleting, that state is maintained during the cache refresh.