### PR TITLE
Force refresh before IncreaseSize

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/README.md
+++ b/cluster-autoscaler/cloudprovider/azure/README.md
@@ -173,10 +173,12 @@ When using K8s versions older than v1.18, we recommend using at least **v.1.17.5
 As for CA versions older than 1.18, we recommend using at least **v.1.17.2, v1.16.5, v1.15.6**.
 
 In addition, cluster-autoscaler exposes a `AZURE_VMSS_CACHE_TTL` environment variable which controls the rate of `GetVMScaleSet` being made. By default, this is 15 seconds but setting this to a higher value such as 60 seconds can protect against API throttling. The caches used are proactively incremented and decremented with the scale up and down operations and this higher value doesn't have any noticeable impact on performance. **Note that the value is in seconds**
+`AZURE_VMSS_CACHE_FORCE_REFRESH` can also be set to always refresh the cache before an upscale. 
 
-| Config Name | Default | Environment Variable | Cloud Config File |
-| ----------- | ------- | -------------------- | ----------------- |
-| VmssCacheTTL | 60 | AZURE_VMSS_CACHE_TTL | vmssCacheTTL |
+| Config Name           | Default | Environment Variable           | Cloud Config File     |
+|-----------------------|--------|--------------------------------|------------------------|
+| VmssCacheTTL          | 60     | AZURE_VMSS_CACHE_TTL           | vmssCacheTTL           |
+| VmssCacheForceRefresh | false  | AZURE_VMSS_CACHE_FORCE_REFRESH | vmssCacheForceRefresh  | 
 
 The `AZURE_VMSS_VMS_CACHE_TTL` environment variable affects the `GetScaleSetVms` (VMSS VM List) calls rate. The default value is 300 seconds.
 A configurable jitter (`AZURE_VMSS_VMS_CACHE_JITTER` environment variable, default 0) expresses the maximum number of second that will be subtracted from that initial VMSS cache TTL after a new VMSS is discovered by the cluster-autoscaler: this can prevent a dogpile effect on clusters having many VMSS.

--- a/cluster-autoscaler/cloudprovider/azure/azure_config.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_config.go
@@ -119,6 +119,9 @@ type Config struct {
 	// VMSS metadata cache TTL in seconds, only applies for vmss type
 	VmssCacheTTL int64 `json:"vmssCacheTTL" yaml:"vmssCacheTTL"`
 
+	// VMSS cache option to force refresh of the vmss capacity before an upscale
+	VmssCacheForceRefresh bool `json:"vmssCacheForceRefresh" yaml:"vmssCacheForceRefresh"`
+
 	// VMSS instances cache TTL in seconds, only applies for vmss type
 	VmssVmsCacheTTL int64 `json:"vmssVmsCacheTTL" yaml:"vmssVmsCacheTTL"`
 
@@ -212,6 +215,13 @@ func BuildAzureConfig(configReader io.Reader) (*Config, error) {
 			cfg.VmssCacheTTL, err = strconv.ParseInt(vmssCacheTTL, 10, 0)
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse AZURE_VMSS_CACHE_TTL %q: %v", vmssCacheTTL, err)
+			}
+		}
+
+		if vmssCacheForceRefresh := os.Getenv("AZURE_VMSS_CACHE_FORCE_REFRESH"); vmssCacheForceRefresh != "" {
+			cfg.VmssCacheForceRefresh, err = strconv.ParseBool(vmssCacheForceRefresh)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse AZURE_VMSS_CACHE_FORCE_REFRESH %q: %v", vmssCacheForceRefresh, err)
 			}
 		}
 


### PR DESCRIPTION
Adds an option `AZURE_VMSS_CACHE_FORCE_REFRESH` to force the refresh of the VMSS cache (not VMSS VMs cache per scale set) before an upscale is triggered. This ensures that the size that will be considered during the upscale is up to date, and minimizes the potential for skew in accounting by relying on `scaleSet.curSize`.

This also adds a check and some more logging on the upscale path to ensure that an 'upscale' to a size that's lower than the current size is never attempted, as this would always delete random instances.