### PR TITLE
[local] Wait for initial cache to sync before starting autoscaling

### DIFF
--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -608,7 +608,11 @@ func buildAutoscaler(debuggingSnapshotter debuggingsnapshot.DebuggingSnapshotter
 	// additional informers might have been registered in the factory during NewAutoscaler.
 	stop := make(chan struct{})
 	informerFactory.Start(stop)
+	klog.V(1).Info("Started shared informer factory, waiting for initial cache sync")
 
+	informerStartTime := time.Now()
+	informerFactory.WaitForCacheSync(stop)
+	klog.V(1).Infof("Shared informer factory finished initial sync, took %v", time.Since(informerStartTime))
 	return autoscaler, nil
 }
 


### PR DESCRIPTION
Adds a call to WaitForCacheSync after the sharedInformerFactory has been started; This will help remediate against cases where the API server is (partially) unavailable and prevent empty, unsynced cache data from being served to consumers.


