### PR TITLE
Benh/vpa 1.0.0 cherry picks

### DIFF
--- a/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/README.md
@@ -337,6 +337,42 @@ The annotation format is the following:
 vpa-post-processor.kubernetes.io/{containerName}_integerCPU=true
 ```
 
+### Custom safety margin per VPA
+
+By default, the VPA recommender adds a safety margin of 15% to its CPU and Memory recommendation which can be adjusted by passing the `recommendation-margin-fraction` flag to the invocation command. However,
+this parameter is unique and applies to all VPAs under the recommender. Some application would benefit from a different safety margin. Moreover, one may want to pass the recommendation through a custom function
+(e.g.: affine, log). To activate this feature, pass the flag `--safety-margin-modifier-post-processor-enabled` when you start the recommender. The post-processor only acts on containers having a specific configuration.
+This configuration consists in an annotation on your VPA object for each impacted container. The annotation format is the following:
+
+```
+vpa-post-processor.kubernetes.io/{containerName}_safetyMarginModifier={"cpu": {"function": "Linear", parameters: [1.10]}, "memory": {"function": "Linear", parameters: [1.30]}}
+```
+
+You can also specify a wildcard modifier:
+
+```
+vpa-post-processor.kubernetes.io/{containerName}_safetyMarginModifier={"*": {"function": "Linear", parameters: [1.10]}}
+```
+
+Note: before applying the custom margin modifier, the post processor reverts the default safety margin applied to the recommendation.
+
+Available functions:
+
+Name | Parameters | Formula | Description
+|-|-|-|-|
+| Linear | [slope] | slope \* recommendation | Similar to the default safety margin. Multiplies the recommendation by a safety factor (e.g: 15% margin means a factor of 1.15)
+| Affine | [constant, slope] | constant + slope \* recommendation | Similar to the default safety margin but also adds a constant to the recommendation
+| Log | [factor] | recommendation \* (1 + factor \* log10(recommendation)) | Add to the recommendation a value proportional to the logarithm of the base recommendation
+| Exponential | [exponent, factor] | recommendation \* (1 + factor \* recommendation ^ exponent) | Add to the recommendation a value proportional to a power of the base recommendation (note: most of the time, you will want an exponent lower than 1)
+
+Note: as some modifiers' output depend on the scale of the resoure Quantity, here are the units used by the modifiers:
+
+Resource Name | Unit
+|-|-|
+| CPU | millicores
+| Memory | Bytes
+
+
 # Known limitations
 
 * Whenever VPA updates the pod resources, the pod is recreated, which causes all

--- a/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
@@ -427,6 +427,7 @@ spec:
                     - Initial
                     - Recreate
                     - Auto
+                    - Trigger
                     type: string
                 type: object
             required:

--- a/vertical-pod-autoscaler/enhancements/xxxx-update-mode-trigger/README.md
+++ b/vertical-pod-autoscaler/enhancements/xxxx-update-mode-trigger/README.md
@@ -1,0 +1,74 @@
+# KEP-XXXX: Patch Well Known Controllers instead of Pods
+
+<!-- toc -->
+- [Summary](#summary)
+- [Motivation](#motivation)
+    - [Goals](#goals)
+    - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+- [Design Details](#design-details)
+    - [Test Plan](#test-plan)
+- [Implementation History](#implementation-history)
+- [Alternatives](#alternatives)
+    - [Update the eviction API](#update-the-eviction-api)
+<!-- /toc -->
+
+## Summary
+
+The default behaviour of VPA Admission controller is to patch Pods when `UpdateModde`
+is different from `Off`. This works fine if we accept vertical scaling outside standard deployments.
+
+For a wide range of application we cannot guarantee that such changes will not
+result in degraded performances, or worse, break the application. Because of that
+users might want to do that only as part of their regular deployment procedure. This
+makes even more sense when those deployments are done to multiple kubernetes clusters
+with safeguards between them.
+
+## Motivation
+
+The motivation behind the change is to give VPA users a way to apply resource
+changes only when they deploy their application.
+
+### Goals
+
+- Main: allow users to apply resource recommendation on demand (mostly during application deployment)
+
+### Non-Goals
+
+- Get rid of other update modes
+
+## Proposal
+
+The proposal is to extend the existing admission controller.
+
+A new `vpaTrigger` annotation on the controller (deployment/sts) and the associated `UpdateMode` `Trigger`
+in the VPA object will be created. When  an admitted resource is handled by the admission controller,
+recommendations will be applied only  if the `vpaTrigger` annotation is present and equal to `true`. 
+
+The admission controller will now also watch and mutate creation and updates of
+`Deployment` and `StatefulSet`. It will do so by changing the `PodTemplateSpec` in the
+same way it updates the `PodSpec` of a `Pod`.
+
+## Design Details
+
+- If `UpdateMode` is set to `Trigger` and the `vpaTrigger` annotation is equal to `true`:
+the recommendations are applied and the `vpaTrigger` annotation is set to `triggered`.
+- Otherwise, nothing happens.
+
+The intent is to let users trigger a recommendation using:
+`kubectl annotate deployment/hamster-deployment vpaTrigger=true`
+
+The will also be able to simply set `vpaTrigger=true` in their charts to
+trigger a new recommendation at each `apply` of the chart.
+
+To make the code easier to rebase, the new resource handler will re-use most
+of the pod resource handlers. If this ever get merged part of the code will be
+re-worked to deal with `PodSpec` instead of `Pod`
+
+### Test Plan
+
+Add unit tests that cover the new code paths.
+
+## Implementation History
+
+- 2022-11-28: initial version

--- a/vertical-pod-autoscaler/examples/hamster-workload.yaml
+++ b/vertical-pod-autoscaler/examples/hamster-workload.yaml
@@ -1,0 +1,122 @@
+# This config creates a deployment with two pods, each requesting 100 millicores
+# and trying to utilize slightly above 500 millicores (repeatedly using CPU for
+# 0.5s and sleeping 0.5s).
+# It also creates a corresponding Vertical Pod Autoscaler that adjusts the
+# requests.
+---
+apiVersion: "autoscaling.k8s.io/v1"
+kind: VerticalPodAutoscaler
+metadata:
+  name: hamster-deployment-vpa
+spec:
+  # recommenders field can be unset when using the default recommender.
+  # When using an alternative recommender, the alternative recommender's name
+  # can be specified as the following in a list.
+  # recommenders: 
+  #   - name: 'alternative'
+  targetRef:
+    apiVersion: "apps/v1"
+    kind: Deployment
+    name: hamster-deployment
+  updatePolicy:
+    updateMode: Trigger
+  resourcePolicy:
+    containerPolicies:
+      - containerName: '*'
+        minAllowed:
+          cpu: 10m
+          memory: 50Mi
+        maxAllowed:
+          cpu: 600m
+          memory: 500Mi
+        controlledResources: ["cpu", "memory"]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hamster-deployment
+  annotations:
+    vpaTrigger: "true"
+spec:
+  selector:
+    matchLabels:
+      app: hamster-deployment
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: hamster-deployment
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534 # nobody
+      containers:
+        - name: hamster
+          image: k8s.gcr.io/ubuntu-slim:0.1
+          resources:
+            requests:
+              cpu: 10m
+              memory: 50Mi
+          command: ["/bin/sh"]
+          args:
+            - "-c"
+            - "while true; do timeout 0.5s yes >/dev/null; sleep 0.5s; done"
+---
+apiVersion: "autoscaling.k8s.io/v1"
+kind: VerticalPodAutoscaler
+metadata:
+  name: hamster-statefulset-vpa
+spec:
+  # recommenders field can be unset when using the default recommender.
+  # When using an alternative recommender, the alternative recommender's name
+  # can be specified as the following in a list.
+  # recommenders:
+  #   - name: 'alternative'
+  targetRef:
+    apiVersion: "apps/v1"
+    kind: StatefulSet
+    name: hamster-statefulset
+  updatePolicy:
+    updateMode: Trigger
+  resourcePolicy:
+    containerPolicies:
+      - containerName: '*'
+        minAllowed:
+          cpu: 10m
+          memory: 50Mi
+        maxAllowed:
+          cpu: 600m
+          memory: 500Mi
+        controlledResources: ["cpu", "memory"]
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: hamster-statefulset
+  annotations:
+    vpaTrigger: "true"
+spec:
+  selector:
+    matchLabels:
+      app: hamster-statefulset
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: hamster-statefulset
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534 # nobody
+      containers:
+        - name: hamster
+          image: k8s.gcr.io/ubuntu-slim:0.1
+          resources:
+            requests:
+              cpu: 10m
+              memory: 50Mi
+          command: ["/bin/sh"]
+          args:
+            - "-c"
+            - "while true; do timeout 0.5s yes >/dev/null; sleep 0.5s; done"
+  serviceName: hamster-statefulset

--- a/vertical-pod-autoscaler/pkg/admission-controller/README.md
+++ b/vertical-pod-autoscaler/pkg/admission-controller/README.md
@@ -7,10 +7,17 @@
 ## Intro
 
 This is a binary that registers itself as a Mutating Admission Webhook
-and because of that is on the path of creating all pods.
+and because of that is on the path of creating all pods and
+creating or updating all deployments and statefulsets.
+
 For each pod creation, it will get a request from the apiserver and it will
 either decide there's no matching VPA configuration or find the corresponding
 one and use current recommendation to set resource requests in the pod.
+
+For each deployment or statefulset creation or update, it will get a request from the
+apiserver and either decide there's no matching VPA configuration or find the corresponding
+one and if `UpdateMode` is set to `Annotation` and the `vpaTrigger: true` annotation is set, it
+will use current recommendation to set resource requests in the pod template spec.
 
 ## Running
 
@@ -29,7 +36,7 @@ up the changes: ```sudo systemctl restart kubelet.service```
    `kubectl create -f ../deploy/admission-controller-deployment.yaml`.
    The first thing this will do is it will register itself with the apiserver as
    Webhook Admission Controller and start changing resource requirements
-   for pods on their creation & updates.
+   for pods, deployments and statefulsets on their creation & updates.
 1. You can specify a path for it to register as a part of the installation process
    by setting `--register-by-url=true` and passing `--webhook-address` and `--webhook-port`.
 

--- a/vertical-pod-autoscaler/pkg/admission-controller/config.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/config.go
@@ -90,6 +90,22 @@ func selfRegistration(clientset *kubernetes.Clientset, caCert []byte, namespace,
 							Resources:   []string{"verticalpodautoscalers"},
 						},
 					},
+					{
+						Operations: []admissionregistration.OperationType{admissionregistration.Create, admissionregistration.Update},
+						Rule: admissionregistration.Rule{
+							APIGroups:   []string{"apps"},
+							APIVersions: []string{"v1"},
+							Resources:   []string{"deployments"},
+						},
+					},
+					{
+						Operations: []admissionregistration.OperationType{admissionregistration.Create, admissionregistration.Update},
+						Rule: admissionregistration.Rule{
+							APIGroups:   []string{"apps"},
+							APIVersions: []string{"v1"},
+							Resources:   []string{"statefulsets"},
+						},
+					},
 				},
 				FailurePolicy:  &failurePolicy,
 				ClientConfig:   RegisterClientConfig,

--- a/vertical-pod-autoscaler/pkg/admission-controller/main.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/main.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -69,6 +70,7 @@ var (
 	registerWebhook    = flag.Bool("register-webhook", true, "If set to true, admission webhook object will be created on start up to register with the API server.")
 	registerByURL      = flag.Bool("register-by-url", false, "If set to true, admission webhook will be registered by URL (webhookAddress:webhookPort) instead of by service name")
 	vpaObjectNamespace = flag.String("vpa-object-namespace", apiv1.NamespaceAll, "Namespace to search for VPA objects. Empty means all namespaces will be used.")
+	allowedResources   = flag.String("allowed-resources", strings.Join([]string{string(apiv1.ResourceCPU), string(apiv1.ResourceMemory)}, ","), "Comma-separated list of resources that can be applied from a VPA.")
 )
 
 func main() {
@@ -96,7 +98,14 @@ func main() {
 		klog.Errorf("Failed to create limitRangeCalculator, falling back to not checking limits. Error message: %s", err)
 		limitRangeCalculator = limitrange.NewNoopLimitsCalculator()
 	}
-	recommendationProvider := recommendation.NewProvider(limitRangeCalculator, vpa_api_util.NewCappingRecommendationProcessor(limitRangeCalculator))
+
+	var allowedResourcesNames []apiv1.ResourceName
+	for _, resourceName := range strings.Split(*allowedResources, ",") {
+		if resourceName != "" {
+			allowedResourcesNames = append(allowedResourcesNames, apiv1.ResourceName(resourceName))
+		}
+	}
+	recommendationProvider := recommendation.NewProvider(limitRangeCalculator, vpa_api_util.NewDefaultRecommendationProcessor(limitRangeCalculator, allowedResourcesNames))
 	vpaMatcher := vpa.NewMatcher(vpaLister, targetSelectorFetcher)
 
 	hostname, err := os.Hostname()

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/deployment/handller_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/deployment/handller_test.go
@@ -1,0 +1,206 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployment
+
+import (
+	"fmt"
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	apiv1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/stretchr/testify/assert"
+
+	resource_admission "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch"
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
+)
+
+type fakePodPreProcessor struct {
+	err error
+}
+
+func (fpp *fakePodPreProcessor) Process(pod apiv1.Pod) (apiv1.Pod, error) {
+	return pod, fpp.err
+}
+
+type fakeVpaMatcher struct {
+	vpa *vpa_types.VerticalPodAutoscaler
+}
+
+func (m *fakeVpaMatcher) GetMatchingVPA(_ *apiv1.Pod) *vpa_types.VerticalPodAutoscaler {
+	return m.vpa
+}
+
+type fakePatchCalculator struct {
+	patches []resource_admission.PatchRecord
+	err     error
+}
+
+func (c *fakePatchCalculator) CalculatePatches(_ *apiv1.Pod, _ *vpa_types.VerticalPodAutoscaler) (
+	[]resource_admission.PatchRecord, error) {
+	return c.patches, c.err
+}
+
+func TestGetPatches(t *testing.T) {
+	testVpa := test.VerticalPodAutoscaler().WithUpdateMode(vpa_types.UpdateModeTrigger).WithName("name").WithContainer("testy-container").Get()
+	testPatchRecord := resource_admission.PatchRecord{
+		Op:    "add",
+		Path:  "some/path",
+		Value: "much",
+	}
+	testPatchRecord2 := resource_admission.PatchRecord{
+		Op:    "add",
+		Path:  "other/path",
+		Value: "not so much",
+	}
+	tests := []struct {
+		name                 string
+		deploymentJson       []byte
+		namespace            string
+		vpa                  *vpa_types.VerticalPodAutoscaler
+		podPreProcessorError error
+		calculators          []patch.Calculator
+		expectPatches        []resource_admission.PatchRecord
+		expectError          error
+	}{
+		{
+			name:                 "invalid JSON",
+			deploymentJson:       []byte("{"),
+			namespace:            "default",
+			vpa:                  testVpa,
+			podPreProcessorError: nil,
+			expectError:          fmt.Errorf("unexpected end of JSON input"),
+		},
+		{
+			name:                 "invalid deployment",
+			deploymentJson:       []byte("{}"),
+			namespace:            "default",
+			vpa:                  testVpa,
+			podPreProcessorError: fmt.Errorf("bad deployment"),
+			expectError:          fmt.Errorf("bad deployment"),
+		},
+		{
+			name:                 "no vpa found",
+			deploymentJson:       []byte("{}"),
+			namespace:            "test",
+			vpa:                  nil,
+			podPreProcessorError: nil,
+			expectError:          nil,
+			expectPatches:        []resource_admission.PatchRecord{},
+		},
+		{
+			name:           "calculator returns error",
+			deploymentJson: []byte("{}"),
+			namespace:      "test",
+			vpa:            testVpa,
+			calculators: []patch.Calculator{&fakePatchCalculator{
+				[]resource_admission.PatchRecord{}, fmt.Errorf("Can't calculate this"),
+			}},
+			podPreProcessorError: nil,
+			expectError:          fmt.Errorf("Can't calculate this"),
+			expectPatches:        []resource_admission.PatchRecord{},
+		},
+		{
+			name:           "second calculator returns error",
+			deploymentJson: []byte("{}"),
+			namespace:      "test",
+			vpa:            testVpa,
+			calculators: []patch.Calculator{
+				&fakePatchCalculator{[]resource_admission.PatchRecord{
+					testPatchRecord,
+				}, nil},
+				&fakePatchCalculator{
+					[]resource_admission.PatchRecord{}, fmt.Errorf("Can't calculate this"),
+				}},
+			podPreProcessorError: nil,
+			expectError:          fmt.Errorf("Can't calculate this"),
+			expectPatches:        []resource_admission.PatchRecord{},
+		},
+		{
+			name:           "patches returned correctly",
+			deploymentJson: []byte("{}"),
+			namespace:      "test",
+			vpa:            testVpa,
+			calculators: []patch.Calculator{
+				&fakePatchCalculator{[]resource_admission.PatchRecord{
+					testPatchRecord,
+					testPatchRecord2,
+				}, nil}},
+			podPreProcessorError: nil,
+			expectError:          nil,
+			expectPatches: []resource_admission.PatchRecord{
+				patch.GetAddEmptyAnnotationsPatch(),
+				testPatchRecord,
+				testPatchRecord2,
+			},
+		},
+		{
+			name:           "patches returned correctly for multiple calculators",
+			deploymentJson: []byte("{}"),
+			namespace:      "test",
+			vpa:            testVpa,
+			calculators: []patch.Calculator{
+				&fakePatchCalculator{[]resource_admission.PatchRecord{
+					testPatchRecord,
+				}, nil},
+				&fakePatchCalculator{[]resource_admission.PatchRecord{
+					testPatchRecord2,
+				}, nil}},
+			podPreProcessorError: nil,
+			expectError:          nil,
+			expectPatches: []resource_admission.PatchRecord{
+				patch.GetAddEmptyAnnotationsPatch(),
+				testPatchRecord,
+				testPatchRecord2,
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("test case: %s", tc.name), func(t *testing.T) {
+			fppp := &fakePodPreProcessor{tc.podPreProcessorError}
+			fvm := &fakeVpaMatcher{vpa: tc.vpa}
+			h := NewResourceHandler(fppp, fvm, tc.calculators)
+			patches, err := h.GetPatches(&admissionv1.AdmissionRequest{
+				Resource: v1.GroupVersionResource{
+					Version: "v1",
+				},
+				Namespace: tc.namespace,
+				Object: runtime.RawExtension{
+					Raw: tc.deploymentJson,
+				},
+			})
+			if tc.expectError == nil {
+				assert.NoError(t, err)
+			} else {
+				if assert.Error(t, err) {
+					assert.Equal(t, tc.expectError.Error(), err.Error())
+				}
+			}
+			if assert.Equal(t, len(tc.expectPatches), len(patches), fmt.Sprintf("got %+v, want %+v", patches, tc.expectPatches)) {
+				for i, gotPatch := range patches {
+					if !patch.EqPatch(gotPatch, tc.expectPatches[i]) {
+						t.Errorf("Expected patch at position %d to be %+v, got %+v", i, tc.expectPatches[i], gotPatch)
+					}
+				}
+			}
+		})
+	}
+}

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/resource_updates.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/resource_updates.go
@@ -26,6 +26,8 @@ import (
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation"
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
+
+	"github.com/go-openapi/jsonpointer"
 )
 
 const (
@@ -105,9 +107,11 @@ func appendPatchesAndAnnotations(patches []resource_admission.PatchRecord, annot
 }
 
 func getAddResourceRequirementValuePatch(i int, kind string, resource core.ResourceName, quantity resource.Quantity) resource_admission.PatchRecord {
+	// Patch fields which can contain '/' characters (e.g. domain-qualified extended resources) must conform
+	// to IETF-6901 and escape those characters
 	return resource_admission.PatchRecord{
 		Op:    "add",
-		Path:  fmt.Sprintf("/spec/containers/%d/resources/%s/%s", i, kind, resource),
+		Path:  fmt.Sprintf("/spec/containers/%d/resources/%s/%s", i, kind, jsonpointer.Escape(resource.String())),
 		Value: quantity.String()}
 }
 

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/update_trigger.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/update_trigger.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch
+
+import (
+	"time"
+
+	core "k8s.io/api/core/v1"
+
+	resource_admission "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource"
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/annotations"
+)
+
+type updateTrigger struct{}
+
+var now = time.Now
+
+func (*updateTrigger) CalculatePatches(pod *core.Pod, _ *vpa_types.VerticalPodAutoscaler) ([]resource_admission.PatchRecord, error) {
+	patches := []resource_admission.PatchRecord{}
+
+	if annotations.HasVpaTrigger(&pod.ObjectMeta) {
+		patches = append(patches, GetAddAnnotationPatch(annotations.VpaTriggerLabel, annotations.GetVpaTriggeredValue(now())))
+	}
+
+	return patches, nil
+}
+
+// NewUpdateTriggerCalculator returns calculator for
+// the trigger annotation patches.
+func NewUpdateTriggerCalculator() Calculator {
+	return &updateTrigger{}
+}

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/update_trigger_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/update_trigger_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch
+
+import (
+	"testing"
+	"time"
+
+	core "k8s.io/api/core/v1"
+
+	resource_admission "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/annotations"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func addVpaUpdateTriggerPatch(value string) *resource_admission.PatchRecord {
+	patch := GetAddAnnotationPatch(annotations.VpaTriggerLabel, value)
+	return &patch
+}
+
+func TestCalculatePatches_UpdateTrigger(t *testing.T) {
+	now = func() time.Time { return time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC) }
+	defer func() {
+		now = time.Now
+	}()
+
+	tests := []struct {
+		name          string
+		pod           *core.Pod
+		expectedPatch *resource_admission.PatchRecord
+	}{
+		{
+			name:          "doesn't update pod without trigger annotation",
+			pod:           test.Pod().Get(),
+			expectedPatch: nil,
+		},
+		{
+			name:          "update vpa update trigger annotation",
+			pod:           test.Pod().WithAnnotations(map[string]string{annotations.VpaTriggerLabel: annotations.VpaTriggerEnabled}).Get(),
+			expectedPatch: addVpaUpdateTriggerPatch(annotations.GetVpaTriggeredValue(now())),
+		},
+		{
+			name:          "doesn't vpa update trigger annotation if already triggered",
+			pod:           test.Pod().WithAnnotations(map[string]string{annotations.VpaTriggerLabel: annotations.GetVpaTriggeredValue(now())}).Get(),
+			expectedPatch: nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := NewUpdateTriggerCalculator()
+			patches, err := c.CalculatePatches(tc.pod, nil)
+			assert.NoError(t, err)
+			if tc.expectedPatch != nil {
+				if assert.Len(t, patches, 1, "Unexpected number of patches.") {
+					AssertEqPatch(t, *tc.expectedPatch, patches[0])
+				}
+			} else {
+				assert.Empty(t, patches)
+			}
+		})
+	}
+}

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider.go
@@ -114,7 +114,7 @@ func (p *recommendationProvider) GetContainersResourcesForPod(pod *core.Pod, vpa
 	// Ensure that we are not propagating empty resource key if any.
 	for _, resource := range containerResources {
 		if resource.RemoveEmptyResourceKeyIfAny() {
-			klog.Infof("An empty resource key was found and purged for pod=%s/%s with vpa=", pod.Namespace, pod.Name, vpa.Name)
+			klog.Error("An empty resource key was found and purged for pod=%s/%s with vpa=", pod.Namespace, pod.Name, vpa.Name)
 		}
 	}
 

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider_test.go
@@ -116,10 +116,11 @@ func TestUpdateResourceRequests(t *testing.T) {
 		name              string
 		pod               *apiv1.Pod
 		vpa               *vpa_types.VerticalPodAutoscaler
+		allowedResources  []apiv1.ResourceName
 		expectedAction    bool
 		expectedError     error
-		expectedMem       resource.Quantity
-		expectedCPU       resource.Quantity
+		expectedMem       *resource.Quantity
+		expectedCPU       *resource.Quantity
 		expectedCPULimit  *resource.Quantity
 		expectedMemLimit  *resource.Quantity
 		limitRange        *apiv1.LimitRangeItem
@@ -127,74 +128,82 @@ func TestUpdateResourceRequests(t *testing.T) {
 		annotations       vpa_api_util.ContainerToAnnotationsMap
 	}{
 		{
-			name:           "uninitialized pod",
-			pod:            uninitialized,
-			vpa:            vpa,
-			expectedAction: true,
-			expectedMem:    resource.MustParse("200Mi"),
-			expectedCPU:    resource.MustParse("2"),
+			name:             "uninitialized pod",
+			pod:              uninitialized,
+			vpa:              vpa,
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceCPU, apiv1.ResourceMemory},
+			expectedAction:   true,
+			expectedMem:      mustParseResourcePointer("200Mi"),
+			expectedCPU:      mustParseResourcePointer("2"),
 		},
 		{
-			name:           "target below min",
-			pod:            uninitialized,
-			vpa:            targetBelowMinVPA,
-			expectedAction: true,
-			expectedMem:    resource.MustParse("300Mi"), // MinMemory is expected to be used
-			expectedCPU:    resource.MustParse("4"),     // MinCpu is expected to be used
+			name:             "target below min",
+			pod:              uninitialized,
+			vpa:              targetBelowMinVPA,
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceCPU, apiv1.ResourceMemory},
+			expectedAction:   true,
+			expectedMem:      mustParseResourcePointer("300Mi"), // MinMemory is expected to be used
+			expectedCPU:      mustParseResourcePointer("4"),     // MinCpu is expected to be used
 			annotations: vpa_api_util.ContainerToAnnotationsMap{
 				containerName: []string{"cpu capped to minAllowed", "memory capped to minAllowed"},
 			},
 		},
 		{
-			name:           "target above max",
-			pod:            uninitialized,
-			vpa:            targetAboveMaxVPA,
-			expectedAction: true,
-			expectedMem:    resource.MustParse("1Gi"), // MaxMemory is expected to be used
-			expectedCPU:    resource.MustParse("5"),   // MaxCpu is expected to be used
+			name:             "target above max",
+			pod:              uninitialized,
+			vpa:              targetAboveMaxVPA,
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceCPU, apiv1.ResourceMemory},
+			expectedAction:   true,
+			expectedMem:      mustParseResourcePointer("1Gi"), // MaxMemory is expected to be used
+			expectedCPU:      mustParseResourcePointer("5"),   // MaxCpu is expected to be used
 			annotations: vpa_api_util.ContainerToAnnotationsMap{
 				containerName: []string{"cpu capped to maxAllowed", "memory capped to maxAllowed"},
 			},
 		},
 		{
-			name:           "initialized pod",
-			pod:            initialized,
-			vpa:            vpa,
-			expectedAction: true,
-			expectedMem:    resource.MustParse("200Mi"),
-			expectedCPU:    resource.MustParse("2"),
+			name:             "initialized pod",
+			pod:              initialized,
+			vpa:              vpa,
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceCPU, apiv1.ResourceMemory},
+			expectedAction:   true,
+			expectedMem:      mustParseResourcePointer("200Mi"),
+			expectedCPU:      mustParseResourcePointer("2"),
 		},
 		{
-			name:           "high memory",
-			pod:            initialized,
-			vpa:            vpaWithHighMemory,
-			expectedAction: true,
-			expectedMem:    resource.MustParse("1000Mi"),
-			expectedCPU:    resource.MustParse("2"),
+			name:             "high memory",
+			pod:              initialized,
+			vpa:              vpaWithHighMemory,
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceCPU, apiv1.ResourceMemory},
+			expectedAction:   true,
+			expectedMem:      mustParseResourcePointer("1000Mi"),
+			expectedCPU:      mustParseResourcePointer("2"),
 		},
 		{
-			name:           "empty recommendation",
-			pod:            initialized,
-			vpa:            vpaWithEmptyRecommendation,
-			expectedAction: true,
-			expectedMem:    resource.MustParse("0"),
-			expectedCPU:    resource.MustParse("0"),
+			name:             "empty recommendation",
+			pod:              initialized,
+			vpa:              vpaWithEmptyRecommendation,
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceCPU, apiv1.ResourceMemory},
+			expectedAction:   true,
+			expectedMem:      nil,
+			expectedCPU:      nil,
 		},
 		{
-			name:           "nil recommendation",
-			pod:            initialized,
-			vpa:            vpaWithNilRecommendation,
-			expectedAction: true,
-			expectedMem:    resource.MustParse("0"),
-			expectedCPU:    resource.MustParse("0"),
+			name:             "nil recommendation",
+			pod:              initialized,
+			vpa:              vpaWithNilRecommendation,
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceCPU, apiv1.ResourceMemory},
+			expectedAction:   true,
+			expectedMem:      nil,
+			expectedCPU:      nil,
 		},
 		{
 			name:             "guaranteed resources",
 			pod:              limitsMatchRequestsPod,
 			vpa:              vpa,
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceCPU, apiv1.ResourceMemory},
 			expectedAction:   true,
-			expectedMem:      resource.MustParse("200Mi"),
-			expectedCPU:      resource.MustParse("2"),
+			expectedMem:      mustParseResourcePointer("200Mi"),
+			expectedCPU:      mustParseResourcePointer("2"),
 			expectedCPULimit: mustParseResourcePointer("2"),
 			expectedMemLimit: mustParseResourcePointer("200Mi"),
 		},
@@ -202,9 +211,10 @@ func TestUpdateResourceRequests(t *testing.T) {
 			name:             "guaranteed resources - no request",
 			pod:              limitsNoRequestsPod,
 			vpa:              vpa,
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceCPU, apiv1.ResourceMemory},
 			expectedAction:   true,
-			expectedMem:      resource.MustParse("200Mi"),
-			expectedCPU:      resource.MustParse("2"),
+			expectedMem:      mustParseResourcePointer("200Mi"),
+			expectedCPU:      mustParseResourcePointer("2"),
 			expectedCPULimit: mustParseResourcePointer("2"),
 			expectedMemLimit: mustParseResourcePointer("200Mi"),
 		},
@@ -212,9 +222,10 @@ func TestUpdateResourceRequests(t *testing.T) {
 			name:             "proportional limit - as default",
 			pod:              podWithDoubleLimit,
 			vpa:              vpa,
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceCPU, apiv1.ResourceMemory},
 			expectedAction:   true,
-			expectedCPU:      resource.MustParse("2"),
-			expectedMem:      resource.MustParse("200Mi"),
+			expectedCPU:      mustParseResourcePointer("2"),
+			expectedMem:      mustParseResourcePointer("200Mi"),
 			expectedCPULimit: mustParseResourcePointer("4"),
 			expectedMemLimit: mustParseResourcePointer("400Mi"),
 		},
@@ -222,27 +233,30 @@ func TestUpdateResourceRequests(t *testing.T) {
 			name:             "proportional limit - set explicit",
 			pod:              podWithDoubleLimit,
 			vpa:              resourceRequestsAndLimitsVPA,
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceCPU, apiv1.ResourceMemory},
 			expectedAction:   true,
-			expectedCPU:      resource.MustParse("2"),
-			expectedMem:      resource.MustParse("200Mi"),
+			expectedCPU:      mustParseResourcePointer("2"),
+			expectedMem:      mustParseResourcePointer("200Mi"),
 			expectedCPULimit: mustParseResourcePointer("4"),
 			expectedMemLimit: mustParseResourcePointer("400Mi"),
 		},
 		{
-			name:           "disabled limit scaling",
-			pod:            podWithDoubleLimit,
-			vpa:            resourceRequestsOnlyVPA,
-			expectedAction: true,
-			expectedCPU:    resource.MustParse("2"),
-			expectedMem:    resource.MustParse("200Mi"),
+			name:             "disabled limit scaling",
+			pod:              podWithDoubleLimit,
+			vpa:              resourceRequestsOnlyVPA,
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceCPU, apiv1.ResourceMemory},
+			expectedAction:   true,
+			expectedCPU:      mustParseResourcePointer("2"),
+			expectedMem:      mustParseResourcePointer("200Mi"),
 		},
 		{
-			name:           "disabled limit scaling - requests capped at limit",
-			pod:            podWithDoubleLimit,
-			vpa:            resourceRequestsOnlyVPAHighTarget,
-			expectedAction: true,
-			expectedCPU:    resource.MustParse("2"),
-			expectedMem:    resource.MustParse("200Mi"),
+			name:             "disabled limit scaling - requests capped at limit",
+			pod:              podWithDoubleLimit,
+			vpa:              resourceRequestsOnlyVPAHighTarget,
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceCPU, apiv1.ResourceMemory},
+			expectedAction:   true,
+			expectedCPU:      mustParseResourcePointer("2"),
+			expectedMem:      mustParseResourcePointer("200Mi"),
 			annotations: vpa_api_util.ContainerToAnnotationsMap{
 				containerName: []string{
 					"cpu capped to container limit",
@@ -254,9 +268,10 @@ func TestUpdateResourceRequests(t *testing.T) {
 			name:             "limit over int64",
 			pod:              podWithTenfoldLimit,
 			vpa:              vpaWithExabyteRecommendation,
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceCPU, apiv1.ResourceMemory},
 			expectedAction:   true,
-			expectedCPU:      resource.MustParse("1Ei"),
-			expectedMem:      resource.MustParse("1Ei"),
+			expectedCPU:      mustParseResourcePointer("1Ei"),
+			expectedMem:      mustParseResourcePointer("1Ei"),
 			expectedCPULimit: resource.NewMilliQuantity(math.MaxInt64, resource.DecimalExponent),
 			expectedMemLimit: resource.NewQuantity(math.MaxInt64, resource.DecimalExponent),
 			annotations: vpa_api_util.ContainerToAnnotationsMap{
@@ -270,6 +285,7 @@ func TestUpdateResourceRequests(t *testing.T) {
 			name:              "limit range calculation error",
 			pod:               initialized,
 			vpa:               vpa,
+			allowedResources:  []apiv1.ResourceName{apiv1.ResourceCPU, apiv1.ResourceMemory},
 			limitRangeCalcErr: fmt.Errorf("oh no"),
 			expectedAction:    false,
 			expectedError:     fmt.Errorf("error getting containerLimitRange: oh no"),
@@ -278,9 +294,10 @@ func TestUpdateResourceRequests(t *testing.T) {
 			name:             "proportional limit from default",
 			pod:              initialized,
 			vpa:              vpa,
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceCPU, apiv1.ResourceMemory},
 			expectedAction:   true,
-			expectedCPU:      resource.MustParse("2"),
-			expectedMem:      resource.MustParse("200Mi"),
+			expectedCPU:      mustParseResourcePointer("2"),
+			expectedMem:      mustParseResourcePointer("200Mi"),
 			expectedCPULimit: mustParseResourcePointer("2"),
 			expectedMemLimit: mustParseResourcePointer("200Mi"),
 			limitRange: &apiv1.LimitRangeItem{
@@ -291,12 +308,28 @@ func TestUpdateResourceRequests(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:             "memory recommendation filtered out",
+			pod:              initialized,
+			vpa:              vpa,
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceCPU},
+			expectedAction:   true,
+			expectedCPU:      mustParseResourcePointer("2"),
+		},
+		{
+			name:             "cpu recommendation filtered out",
+			pod:              initialized,
+			vpa:              vpa,
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceMemory},
+			expectedAction:   true,
+			expectedMem:      mustParseResourcePointer("200Mi"),
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			recommendationProvider := &recommendationProvider{
-				recommendationProcessor: vpa_api_util.NewCappingRecommendationProcessor(limitrange.NewNoopLimitsCalculator()),
+				recommendationProcessor: vpa_api_util.NewDefaultRecommendationProcessor(limitrange.NewNoopLimitsCalculator(), tc.allowedResources),
 				limitsRangeCalculator: &fakeLimitRangeCalculator{
 					containerLimitRange: tc.limitRange,
 					containerErr:        tc.limitRangeCalcErr,
@@ -313,11 +346,23 @@ func TestUpdateResourceRequests(t *testing.T) {
 
 				assert.NotContains(t, resources, "", "expected empty resource to be removed")
 
-				cpuRequest := resources[0].Requests[apiv1.ResourceCPU]
-				assert.Equal(t, tc.expectedCPU.Value(), cpuRequest.Value(), "cpu request doesn't match")
+				cpuRequest, cpuRequestPresent := resources[0].Requests[apiv1.ResourceCPU]
+				if tc.expectedCPU == nil {
+					assert.False(t, cpuRequestPresent, "expected no cpu request, got %s", cpuRequest.String())
+				} else {
+					if assert.True(t, cpuRequestPresent, "expected cpu request, but it's missing") {
+						assert.Equal(t, tc.expectedCPU.Value(), cpuRequest.Value(), "cpu request doesn't match")
+					}
+				}
 
-				memoryRequest := resources[0].Requests[apiv1.ResourceMemory]
-				assert.Equal(t, tc.expectedMem.Value(), memoryRequest.Value(), "memory request doesn't match")
+				memoryRequest, memoryRequestPresent := resources[0].Requests[apiv1.ResourceMemory]
+				if tc.expectedMem == nil {
+					assert.False(t, memoryRequestPresent, "expected no mem request, got %s", memoryRequest.String())
+				} else {
+					if assert.True(t, memoryRequestPresent, "expected memory request, but it's missing") {
+						assert.Equal(t, tc.expectedMem.Value(), memoryRequest.Value(), "memory request doesn't match")
+					}
+				}
 
 				cpuLimit, cpuLimitPresent := resources[0].Limits[apiv1.ResourceCPU]
 				if tc.expectedCPULimit == nil {

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/statefulset/handler.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/statefulset/handler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,91 +14,65 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package pod
+package statefulset
 
 import (
 	"encoding/json"
 	"fmt"
 
 	admissionv1 "k8s.io/api/admission/v1"
-	v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
-
 	resource_admission "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource"
+
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/workloads"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/admission"
+	"k8s.io/klog/v2"
 )
 
-// resourceHandler builds patches for Pods.
+// resourceHandler builds patches for StatefulSets.
 type resourceHandler struct {
-	preProcessor     PreProcessor
-	vpaMatcher       vpa.Matcher
-	patchCalculators []patch.Calculator
+	workloads.WorkloadResourceHandler
 }
 
 // NewResourceHandler creates new instance of resourceHandler.
-func NewResourceHandler(preProcessor PreProcessor, vpaMatcher vpa.Matcher, patchCalculators []patch.Calculator) resource_admission.Handler {
+func NewResourceHandler(preProcessor pod.PreProcessor, vpaMatcher vpa.Matcher, patchCalculators []patch.Calculator) resource_admission.Handler {
 	return &resourceHandler{
-		preProcessor:     preProcessor,
-		vpaMatcher:       vpaMatcher,
-		patchCalculators: patchCalculators,
+		*workloads.NewResourceHandler(preProcessor, vpaMatcher, patchCalculators),
 	}
 }
 
 // AdmissionResource returns resource type this handler accepts.
 func (h *resourceHandler) AdmissionResource() admission.AdmissionResource {
-	return admission.Pod
+	return admission.StatefulSet
 }
 
 // GroupResource returns Group and Resource type this handler accepts.
 func (h *resourceHandler) GroupResource() metav1.GroupResource {
-	return metav1.GroupResource{Group: "", Resource: "pods"}
+	return metav1.GroupResource{Group: "apps", Resource: "statefulsets"}
 }
 
 // DisallowIncorrectObjects decides whether incorrect objects (eg. unparsable, not passing validations) should be disallowed by Admission Server.
 func (h *resourceHandler) DisallowIncorrectObjects() bool {
-	// Incorrect Pods are validated by API Server.
+	// Incorrect StatefulSets are validated by API Server.
 	return false
 }
 
-// GetPatches builds patches for Pod in given admission request.
+// GetPatches builds patches for StatefulSets in given admission request.
 func (h *resourceHandler) GetPatches(ar *admissionv1.AdmissionRequest) ([]resource_admission.PatchRecord, error) {
 	if ar.Resource.Version != "v1" {
-		return nil, fmt.Errorf("only v1 Pods are supported")
+		return nil, fmt.Errorf("only v1 statefulsets are supported")
 	}
 	raw, namespace := ar.Object.Raw, ar.Namespace
-	pod := v1.Pod{}
-	if err := json.Unmarshal(raw, &pod); err != nil {
-		return nil, err
-	}
-	if len(pod.Name) == 0 {
-		pod.Name = pod.GenerateName + "%"
-		pod.Namespace = namespace
-	}
-	klog.V(4).Infof("Admitting pod %v", pod.ObjectMeta)
-	controllingVpa := h.vpaMatcher.GetMatchingVPA(&pod)
-	if controllingVpa == nil {
-		klog.V(4).Infof("No matching VPA found for pod %s/%s", pod.Namespace, pod.Name)
-		return []resource_admission.PatchRecord{}, nil
-	}
-	pod, err := h.preProcessor.Process(pod)
-	if err != nil {
+	sts := v1.StatefulSet{}
+	if err := json.Unmarshal(raw, &sts); err != nil {
 		return nil, err
 	}
 
-	patches := []resource_admission.PatchRecord{}
-	if pod.Annotations == nil {
-		patches = append(patches, patch.GetAddEmptyAnnotationsPatch())
-	}
-	for _, c := range h.patchCalculators {
-		partialPatches, err := c.CalculatePatches(&pod, controllingVpa)
-		if err != nil {
-			return []resource_admission.PatchRecord{}, err
-		}
-		patches = append(patches, partialPatches...)
-	}
+	klog.V(4).Infof("Admitting statefulset %v", sts.ObjectMeta)
 
-	return patches, nil
+	return h.GetPatchesForWorkload(namespace, &sts.ObjectMeta, &sts.Spec.Template)
 }

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler.go
@@ -25,10 +25,11 @@ import (
 	apires "k8s.io/apimachinery/pkg/api/resource"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource"
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/admission"
-	"k8s.io/klog/v2"
 )
 
 var (
@@ -37,6 +38,7 @@ var (
 		vpa_types.UpdateModeInitial:  struct{}{},
 		vpa_types.UpdateModeRecreate: struct{}{},
 		vpa_types.UpdateModeAuto:     struct{}{},
+		vpa_types.UpdateModeTrigger:  struct{}{},
 	}
 
 	possibleScalingModes = map[vpa_types.ContainerScalingMode]interface{}{

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/matcher.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/matcher.go
@@ -19,11 +19,13 @@ package vpa
 import (
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/klog/v2"
+
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	vpa_lister "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/target"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/annotations"
 	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
-	"k8s.io/klog/v2"
 )
 
 // Matcher is capable of returning a single matching VPA object
@@ -52,8 +54,16 @@ func (m *matcher) GetMatchingVPA(pod *core.Pod) *vpa_types.VerticalPodAutoscaler
 	}
 	onConfigs := make([]*vpa_api_util.VpaWithSelector, 0)
 	for _, vpaConfig := range configs {
-		if vpa_api_util.GetUpdateMode(vpaConfig) == vpa_types.UpdateModeOff {
+		updateMode := vpa_api_util.GetUpdateMode(vpaConfig)
+		if updateMode == vpa_types.UpdateModeOff {
 			continue
+		}
+		if updateMode == vpa_types.UpdateModeTrigger {
+			if !annotations.HasVpaTrigger(&pod.ObjectMeta) {
+				klog.V(3).Infof("skipping VPA object %v with UpdateMode %s because %s does not have the `%s:%s` annotation.",
+					vpaConfig.Name, updateMode, pod.Name, annotations.VpaTriggerLabel, annotations.VpaTriggerEnabled)
+				continue
+			}
 		}
 		selector, err := m.selectorFetcher.Fetch(vpaConfig)
 		if err != nil {

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/workloads/utils.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/workloads/utils.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workloads
+
+import (
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+
+	resource_admission "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa"
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/annotations"
+	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
+)
+
+// WorkloadResourceHandler builds patches for Workloads.
+type WorkloadResourceHandler struct {
+	preProcessor     pod.PreProcessor
+	vpaMatcher       vpa.Matcher
+	patchCalculators []patch.Calculator
+}
+
+// NewResourceHandler creates new instance of resourceHandler.
+func NewResourceHandler(preProcessor pod.PreProcessor, vpaMatcher vpa.Matcher, patchCalculators []patch.Calculator) *WorkloadResourceHandler {
+	return &WorkloadResourceHandler{
+		preProcessor:     preProcessor,
+		vpaMatcher:       vpaMatcher,
+		patchCalculators: patchCalculators,
+	}
+}
+
+// GetPatchesForWorkload builds patches for Pod in given admission request.
+func (h *WorkloadResourceHandler) GetPatchesForWorkload(namespace string, objectMeta *metav1.ObjectMeta, podTemplateSpec *v1.PodTemplateSpec) ([]resource_admission.PatchRecord, error) {
+	if len(objectMeta.Name) == 0 {
+		objectMeta.Name = objectMeta.GenerateName + "%"
+		objectMeta.Namespace = namespace
+	}
+
+	// We create a `Pod` to be able to re-use the pod code.
+	pod := PodFromPodTemplateSpec(objectMeta, podTemplateSpec)
+	klog.V(4).Infof("Generating pod %s/%s", pod.Namespace, pod.Name)
+	controllingVpa := h.vpaMatcher.GetMatchingVPA(&pod)
+	if controllingVpa == nil {
+		klog.V(4).Infof("No matching VPA found for %s/%s", objectMeta.Namespace, objectMeta.Name)
+		return []resource_admission.PatchRecord{}, nil
+	}
+	updateMode := vpa_api_util.GetUpdateMode(controllingVpa)
+	if updateMode != vpa_types.UpdateModeTrigger {
+		klog.V(4).Infof("Only UpdateMode=%s is supported for workload, found %s", vpa_types.UpdateModeTrigger, updateMode)
+		return []resource_admission.PatchRecord{}, nil
+	}
+	pod, err := h.preProcessor.Process(pod)
+	if err != nil {
+		return nil, err
+	}
+
+	patches := []resource_admission.PatchRecord{}
+	if objectMeta.Annotations == nil {
+		patches = append(patches, patch.GetAddEmptyAnnotationsPatch())
+	}
+	for _, c := range h.patchCalculators {
+		partialPatches, err := c.CalculatePatches(&pod, controllingVpa)
+		if err != nil {
+			return []resource_admission.PatchRecord{}, err
+		}
+		patches = append(patches, partialPatches...)
+	}
+
+	return FixupPatchesSpecPathForWorkload(patches), nil
+}
+
+// FixupPatchesSpecPathForWorkload takes patches for a pod and adapt them to be applied to a workload.
+func FixupPatchesSpecPathForWorkload(patches []resource_admission.PatchRecord) []resource_admission.PatchRecord {
+	for i, patch := range patches {
+		// If it's a patch to spec, add the path to the PodSpec
+		if strings.HasPrefix(patch.Path, "/spec/") {
+			patches[i].Path = "/spec/template" + patch.Path
+		}
+	}
+	return patches
+}
+
+// PodFromPodTemplateSpec creates a fake Pod object from a PodTemplateSpec. This is used by the workload
+// admission controllers tu re-use as much code as we can without modifying it, it makes rebases easier.
+// If we ever want to upstream this code we should make the pod code more generic.
+func PodFromPodTemplateSpec(objectMeta *metav1.ObjectMeta, podTemplateSpec *v1.PodTemplateSpec) v1.Pod {
+	pod := v1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		// This is important to get the same labels as the pod (which need to match the selector)
+		ObjectMeta: podTemplateSpec.ObjectMeta,
+		Spec:       podTemplateSpec.Spec,
+		Status:     v1.PodStatus{},
+	}
+	// We also need to propagate the trigger annotation that was likely set on the parent.
+	if annotations.HasVpaTrigger(objectMeta) {
+		if pod.Annotations == nil {
+			pod.Annotations = make(map[string]string)
+		}
+		pod.Annotations[annotations.VpaTriggerLabel] = annotations.VpaTriggerEnabled
+	}
+	if pod.Name == "" {
+		pod.Name = objectMeta.Name + "%"
+	}
+	if pod.Namespace == "" {
+		pod.Namespace = objectMeta.Namespace
+	}
+	return pod
+}

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/workloads/utils_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/workloads/utils_test.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workloads
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	resource_admission "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch"
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
+)
+
+type fakePodPreProcessor struct {
+	err error
+}
+
+func (fpp *fakePodPreProcessor) Process(pod apiv1.Pod) (apiv1.Pod, error) {
+	return pod, fpp.err
+}
+
+type fakeVpaMatcher struct {
+	vpa *vpa_types.VerticalPodAutoscaler
+}
+
+func (m *fakeVpaMatcher) GetMatchingVPA(_ *apiv1.Pod) *vpa_types.VerticalPodAutoscaler {
+	return m.vpa
+}
+
+type fakePatchCalculator struct {
+	patches []resource_admission.PatchRecord
+	err     error
+}
+
+func (c *fakePatchCalculator) CalculatePatches(_ *apiv1.Pod, _ *vpa_types.VerticalPodAutoscaler) (
+	[]resource_admission.PatchRecord, error) {
+	return c.patches, c.err
+}
+
+func TestGetPatches(t *testing.T) {
+	testVpa := test.VerticalPodAutoscaler().WithUpdateMode(vpa_types.UpdateModeTrigger).WithName("name").WithContainer("testy-container").Get()
+	testPatchRecord := resource_admission.PatchRecord{
+		Op:    "add",
+		Path:  "some/path",
+		Value: "much",
+	}
+	testPatchRecord2 := resource_admission.PatchRecord{
+		Op:    "add",
+		Path:  "other/path",
+		Value: "not so much",
+	}
+	testPatchRecordSpec := resource_admission.PatchRecord{
+		Op:    "replace",
+		Path:  "/spec/containers/1/resources/requests",
+		Value: "1",
+	}
+	tests := []struct {
+		name                 string
+		namespace            string
+		vpa                  *vpa_types.VerticalPodAutoscaler
+		podPreProcessorError error
+		calculators          []patch.Calculator
+		expectPatches        []resource_admission.PatchRecord
+		expectError          error
+	}{
+		{
+			name:                 "no vpa found",
+			namespace:            "test",
+			vpa:                  nil,
+			podPreProcessorError: nil,
+			expectError:          nil,
+			expectPatches:        []resource_admission.PatchRecord{},
+		},
+		{
+			name: "calculator returns error",
+
+			namespace: "test",
+			vpa:       testVpa,
+			calculators: []patch.Calculator{&fakePatchCalculator{
+				[]resource_admission.PatchRecord{}, fmt.Errorf("Can't calculate this"),
+			}},
+			podPreProcessorError: nil,
+			expectError:          fmt.Errorf("Can't calculate this"),
+			expectPatches:        []resource_admission.PatchRecord{},
+		},
+		{
+			name: "second calculator returns error",
+
+			namespace: "test",
+			vpa:       testVpa,
+			calculators: []patch.Calculator{
+				&fakePatchCalculator{[]resource_admission.PatchRecord{
+					testPatchRecord,
+				}, nil},
+				&fakePatchCalculator{
+					[]resource_admission.PatchRecord{}, fmt.Errorf("Can't calculate this"),
+				}},
+			podPreProcessorError: nil,
+			expectError:          fmt.Errorf("Can't calculate this"),
+			expectPatches:        []resource_admission.PatchRecord{},
+		},
+		{
+			name: "patches returned correctly",
+
+			namespace: "test",
+			vpa:       testVpa,
+			calculators: []patch.Calculator{
+				&fakePatchCalculator{[]resource_admission.PatchRecord{
+					testPatchRecord,
+					testPatchRecord2,
+				}, nil}},
+			podPreProcessorError: nil,
+			expectError:          nil,
+			expectPatches: []resource_admission.PatchRecord{
+				patch.GetAddEmptyAnnotationsPatch(),
+				testPatchRecord,
+				testPatchRecord2,
+			},
+		},
+		{
+			name: "patches returned correctly for multiple calculators",
+
+			namespace: "test",
+			vpa:       testVpa,
+			calculators: []patch.Calculator{
+				&fakePatchCalculator{[]resource_admission.PatchRecord{
+					testPatchRecord,
+				}, nil},
+				&fakePatchCalculator{[]resource_admission.PatchRecord{
+					testPatchRecord2,
+				}, nil}},
+			podPreProcessorError: nil,
+			expectError:          nil,
+			expectPatches: []resource_admission.PatchRecord{
+				patch.GetAddEmptyAnnotationsPatch(),
+				testPatchRecord,
+				testPatchRecord2,
+			},
+		},
+		{
+			name:      "patches returned correctly for spec",
+			namespace: "test",
+			vpa:       testVpa,
+			calculators: []patch.Calculator{
+				&fakePatchCalculator{[]resource_admission.PatchRecord{
+					testPatchRecordSpec,
+				}, nil},
+			},
+			podPreProcessorError: nil,
+			expectError:          nil,
+			expectPatches: []resource_admission.PatchRecord{
+				patch.GetAddEmptyAnnotationsPatch(),
+				{
+					Op:    testPatchRecordSpec.Op,
+					Path:  "/spec/template" + testPatchRecordSpec.Path,
+					Value: testPatchRecordSpec.Value,
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("test case: %s", tc.name), func(t *testing.T) {
+			fppp := &fakePodPreProcessor{tc.podPreProcessorError}
+			fvm := &fakeVpaMatcher{vpa: tc.vpa}
+			h := NewResourceHandler(fppp, fvm, tc.calculators)
+			patches, err := h.GetPatchesForWorkload(
+				tc.namespace,
+				&v1.ObjectMeta{
+					Name:         "",
+					GenerateName: "Foo",
+					Namespace:    "",
+				},
+				&apiv1.PodTemplateSpec{
+					Spec: apiv1.PodSpec{},
+				})
+			if tc.expectError == nil {
+				assert.NoError(t, err)
+			} else {
+				if assert.Error(t, err) {
+					assert.Equal(t, tc.expectError.Error(), err.Error())
+				}
+			}
+			if assert.Equal(t, len(tc.expectPatches), len(patches), fmt.Sprintf("got %+v, want %+v", patches, tc.expectPatches)) {
+				for i, gotPatch := range patches {
+					if !patch.EqPatch(gotPatch, tc.expectPatches[i]) {
+						t.Errorf("Expected patch at position %d to be %+v, got %+v", i, tc.expectPatches[i], gotPatch)
+					}
+				}
+			}
+		})
+	}
+}

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
@@ -150,8 +150,8 @@ type PodUpdatePolicy struct {
 	EvictionRequirements []*EvictionRequirement `json:"evictionRequirements,omitempty" protobuf:"bytes,3,opt,name=evictionRequirements"`
 }
 
-// UpdateMode controls when autoscaler applies changes to the pod resources.
-// +kubebuilder:validation:Enum=Off;Initial;Recreate;Auto
+// UpdateMode controls when autoscaler applies changes to the pod resoures.
+// +kubebuilder:validation:Enum=Off;Initial;Recreate;Auto;Trigger
 type UpdateMode string
 
 const (
@@ -168,9 +168,13 @@ const (
 	UpdateModeRecreate UpdateMode = "Recreate"
 	// UpdateModeAuto means that autoscaler assigns resources on pod creation
 	// and additionally can update them during the lifetime of the pod,
-	// using any available update method. Currently this is equivalent to
+	// using any available update method. Currently, this is equivalent to
 	// Recreate, which is the only available update method.
 	UpdateModeAuto UpdateMode = "Auto"
+	// UpdateModeTrigger means that the autoscaler assigns resource when
+	// the controlling workload (Deployement, Statefulset) or the pod has
+	// the `vpaTrigger: true` annotation.
+	UpdateModeTrigger UpdateMode = "Trigger"
 )
 
 // PodResourcePolicy controls how autoscaler computes the recommended resources

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -22,10 +22,18 @@ import (
 	"time"
 
 	"golang.org/x/time/rate"
-
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	kube_client "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	clientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	v1lister "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
+
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	vpa_clientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
 	vpa_lister "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1"
@@ -35,14 +43,6 @@ import (
 	metrics_updater "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/updater"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/status"
 	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
-	kube_client "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/kubernetes/scheme"
-	clientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	v1lister "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/record"
-	"k8s.io/klog/v2"
 )
 
 // Updater performs updates on pods if recommended by Vertical Pod Autoscaler
@@ -63,6 +63,7 @@ type updater struct {
 	selectorFetcher              target.VpaTargetSelectorFetcher
 	useAdmissionControllerStatus bool
 	statusValidator              status.Validator
+	podLabelSelector             labels.Selector
 }
 
 // NewUpdater creates Updater with given configuration
@@ -80,6 +81,7 @@ func NewUpdater(
 	selectorFetcher target.VpaTargetSelectorFetcher,
 	priorityProcessor priority.PriorityProcessor,
 	namespace string,
+	podLabelSelector labels.Selector,
 ) (Updater, error) {
 	evictionRateLimiter := getRateLimiter(evictionRateLimit, evictionRateBurst)
 	factory, err := eviction.NewPodsEvictionRestrictionFactory(kubeClient, minReplicasForEvicition, evictionToleranceFraction)
@@ -102,6 +104,7 @@ func NewUpdater(
 			status.AdmissionControllerStatusName,
 			statusNamespace,
 		),
+		podLabelSelector: podLabelSelector,
 	}, nil
 }
 
@@ -143,9 +146,10 @@ func (u *updater) RunOnce(ctx context.Context) {
 			continue
 		}
 
+		podSelectorRequirements, _ := u.podLabelSelector.Requirements()
 		vpas = append(vpas, &vpa_api_util.VpaWithSelector{
 			Vpa:      vpa,
-			Selector: selector,
+			Selector: selector.Add(podSelectorRequirements...),
 		})
 	}
 

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
@@ -29,7 +29,8 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
+
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	target_mock "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/target/mock"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/updater/eviction"
@@ -38,7 +39,7 @@ import (
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
 )
 
-func parseLabelSelector(selector string) labels.Selector {
+func parseLabelSelector(selector string) k8slabels.Selector {
 	labelSelector, _ := metav1.ParseToLabelSelector(selector)
 	parsedSelector, _ := metav1.LabelSelectorAsSelector(labelSelector)
 	return parsedSelector
@@ -181,6 +182,7 @@ func testRunOnceBase(
 		useAdmissionControllerStatus: true,
 		statusValidator:              statusValidator,
 		priorityProcessor:            priority.NewProcessor(),
+		podLabelSelector:             k8slabels.Everything(),
 	}
 
 	if expectFetchCalls {
@@ -205,6 +207,7 @@ func TestRunOnceNotingToProcess(t *testing.T) {
 		recommendationProcessor:      &test.FakeRecommendationProcessor{},
 		useAdmissionControllerStatus: true,
 		statusValidator:              newFakeValidator(true),
+		podLabelSelector:             k8slabels.Everything(),
 	}
 	updater.RunOnce(context.Background())
 }

--- a/vertical-pod-autoscaler/pkg/utils/annotations/vpa_trigger.go
+++ b/vertical-pod-autoscaler/pkg/utils/annotations/vpa_trigger.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package annotations
+
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// VpaTriggerLabel is a label used by the vpa trigger annotation.
+	VpaTriggerLabel = "vpaTrigger"
+	// VpaTriggerEnabled is the value of VpaTriggerLabel used to enable the tirgger.
+	VpaTriggerEnabled = "true"
+	// VpaTriggerTriggered is the value of VpaTriggerLabel set once we've triggered an update because of the annotation.
+	VpaTriggerTriggered = "triggered at"
+)
+
+// HasVpaTrigger creates an annotation value for a given pod.
+func HasVpaTrigger(objectMeta *metav1.ObjectMeta) bool {
+	if val, ok := objectMeta.Annotations[VpaTriggerLabel]; ok && val == VpaTriggerEnabled {
+		return true
+	}
+	return false
+}
+
+// GetVpaTriggeredValue returns the value for the VpaTriggerLabel annotation once it has been triggered at a given time.
+func GetVpaTriggeredValue(t time.Time) string {
+	return VpaTriggerTriggered + " " + t.Format(time.RFC3339)
+}

--- a/vertical-pod-autoscaler/pkg/utils/annotations/vpa_trigger_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/annotations/vpa_trigger_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package annotations
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
+)
+
+func TestHasVpaTrigger(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  *v1.Pod
+		want bool
+	}{
+		{
+			name: "without annotation",
+			pod:  test.Pod().Get(),
+			want: false,
+		},
+		{
+			name: "with annotation false",
+			pod:  test.Pod().WithAnnotations(map[string]string{VpaTriggerLabel: "false"}).Get(),
+			want: false,
+		},
+		{
+			name: "with annotation true",
+			pod:  test.Pod().WithAnnotations(map[string]string{VpaTriggerLabel: "true"}).Get(),
+			want: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("test case: %s", tc.name), func(t *testing.T) {
+			got := HasVpaTrigger(&tc.pod.ObjectMeta)
+			assert.Equal(t, got, tc.want)
+		})
+	}
+}

--- a/vertical-pod-autoscaler/pkg/utils/test/test_utils.go
+++ b/vertical-pod-autoscaler/pkg/utils/test/test_utils.go
@@ -74,6 +74,16 @@ func Resources(cpu, mem string) apiv1.ResourceList {
 	return result
 }
 
+// AddResource add a resource to the given resource list
+func AddResource(rl apiv1.ResourceList, resourceName apiv1.ResourceName, value string) apiv1.ResourceList {
+	val, _ := resource.ParseQuantity(value)
+	if rl == nil {
+		rl = apiv1.ResourceList{}
+	}
+	rl[resourceName] = val
+	return rl
+}
+
 // RecommenderAPIMock is a mock of RecommenderAPI
 type RecommenderAPIMock struct {
 	mock.Mock

--- a/vertical-pod-autoscaler/pkg/utils/vpa/allowed_resource_filter.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/allowed_resource_filter.go
@@ -39,9 +39,9 @@ func (p *allowedResourceFilter) Apply(podRecommendation *vpa_types.RecommendedPo
 	conditions []vpa_types.VerticalPodAutoscalerCondition,
 	pod *corev1.Pod) (*vpa_types.RecommendedPodResources, ContainerToAnnotationsMap, error) {
 
-	if podRecommendation == nil || policy == nil {
-		// If there is no recommendation or no policies have been defined then no recommendation can be computed.
-		return podRecommendation, nil, nil
+	if podRecommendation == nil {
+		// If there is no recommendation then no filtered recommendation can be computed.
+		return nil, nil, nil
 	}
 
 	accumulatedContainerToAnnotationsMap := ContainerToAnnotationsMap{}

--- a/vertical-pod-autoscaler/pkg/utils/vpa/allowed_resource_filter.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/allowed_resource_filter.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+)
+
+// NewAllowedResourceFilter is a RecommendationProcessor that restricts which resources from a
+// VPA's recommendation can actually be applied on a container
+func NewAllowedResourceFilter(allowedResources []corev1.ResourceName) RecommendationProcessor {
+	return &allowedResourceFilter{
+		allowedResources: allowedResources,
+	}
+}
+
+type allowedResourceFilter struct {
+	allowedResources []corev1.ResourceName
+}
+
+// Apply chains calls to underlying RecommendationProcessors in order provided on object construction
+func (p *allowedResourceFilter) Apply(podRecommendation *vpa_types.RecommendedPodResources,
+	policy *vpa_types.PodResourcePolicy,
+	conditions []vpa_types.VerticalPodAutoscalerCondition,
+	pod *corev1.Pod) (*vpa_types.RecommendedPodResources, ContainerToAnnotationsMap, error) {
+
+	if podRecommendation == nil || policy == nil {
+		// If there is no recommendation or no policies have been defined then no recommendation can be computed.
+		return podRecommendation, nil, nil
+	}
+
+	accumulatedContainerToAnnotationsMap := ContainerToAnnotationsMap{}
+
+	for i, containerRecommendation := range podRecommendation.ContainerRecommendations {
+		podRecommendation.ContainerRecommendations[i] = filterAllowedContainerResources(containerRecommendation, p.allowedResources)
+	}
+
+	return podRecommendation, accumulatedContainerToAnnotationsMap, nil
+}
+
+func filterAllowedContainerResources(recommendation vpa_types.RecommendedContainerResources, allowedResources []corev1.ResourceName) vpa_types.RecommendedContainerResources {
+	recommendation.Target = filterResourceList(recommendation.Target, allowedResources)
+	recommendation.LowerBound = filterResourceList(recommendation.LowerBound, allowedResources)
+	recommendation.UpperBound = filterResourceList(recommendation.UpperBound, allowedResources)
+	recommendation.UncappedTarget = filterResourceList(recommendation.UncappedTarget, allowedResources)
+	return recommendation
+}
+
+func filterResourceList(resourceList corev1.ResourceList, allowedResources []corev1.ResourceName) corev1.ResourceList {
+	filteredResourceList := corev1.ResourceList{}
+	for resourceName, resourceValue := range resourceList {
+		if containsResource(allowedResources, resourceName) {
+			filteredResourceList[resourceName] = resourceValue
+		}
+	}
+	return filteredResourceList
+}
+
+func containsResource(resourceNames []corev1.ResourceName, target corev1.ResourceName) bool {
+	for _, resourceName := range resourceNames {
+		if target == resourceName {
+			return true
+		}
+	}
+	return false
+}

--- a/vertical-pod-autoscaler/pkg/utils/vpa/allowed_resource_filter_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/allowed_resource_filter_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+)
+
+func TestAllowedResourceFilter(t *testing.T) {
+	tests := []struct {
+		name                   string
+		allowedResources       []apiv1.ResourceName
+		recommendation         vpa_types.RecommendedPodResources
+		expectedRecommendation vpa_types.RecommendedPodResources
+	}{
+		{
+			name: "empty allowed resources produces no recommended values",
+			recommendation: vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					{
+						ContainerName: "container-1",
+						Target: apiv1.ResourceList{
+							apiv1.ResourceCPU:    resource.MustParse("1500m"),
+							apiv1.ResourceMemory: resource.MustParse("64Mi"),
+						},
+						LowerBound: apiv1.ResourceList{
+							apiv1.ResourceCPU:    resource.MustParse("1200m"),
+							apiv1.ResourceMemory: resource.MustParse("48Mi"),
+						},
+						UpperBound: apiv1.ResourceList{
+							apiv1.ResourceCPU:    resource.MustParse("1800m"),
+							apiv1.ResourceMemory: resource.MustParse("80Mi"),
+						},
+						UncappedTarget: apiv1.ResourceList{
+							apiv1.ResourceCPU:    resource.MustParse("2500m"),
+							apiv1.ResourceMemory: resource.MustParse("128Mi"),
+						},
+					},
+					{
+						ContainerName: "container-2",
+						Target: apiv1.ResourceList{
+							apiv1.ResourceCPU:    resource.MustParse("3000m"),
+							apiv1.ResourceMemory: resource.MustParse("128Mi"),
+						},
+						LowerBound: apiv1.ResourceList{
+							apiv1.ResourceCPU:    resource.MustParse("2400m"),
+							apiv1.ResourceMemory: resource.MustParse("96Mi"),
+						},
+						UpperBound: apiv1.ResourceList{
+							apiv1.ResourceCPU:    resource.MustParse("3600m"),
+							apiv1.ResourceMemory: resource.MustParse("160Mi"),
+						},
+						UncappedTarget: apiv1.ResourceList{
+							apiv1.ResourceCPU:    resource.MustParse("50000m"),
+							apiv1.ResourceMemory: resource.MustParse("256Mi"),
+						},
+					},
+				},
+			},
+			expectedRecommendation: vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					{
+						ContainerName:  "container-1",
+						Target:         apiv1.ResourceList{},
+						LowerBound:     apiv1.ResourceList{},
+						UpperBound:     apiv1.ResourceList{},
+						UncappedTarget: apiv1.ResourceList{},
+					},
+					{
+						ContainerName:  "container-2",
+						Target:         apiv1.ResourceList{},
+						LowerBound:     apiv1.ResourceList{},
+						UpperBound:     apiv1.ResourceList{},
+						UncappedTarget: apiv1.ResourceList{},
+					},
+				},
+			},
+		},
+		{
+			name:             "filter partial set of resources",
+			allowedResources: []apiv1.ResourceName{apiv1.ResourceCPU, apiv1.ResourceMemory},
+			recommendation: vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					{
+						ContainerName: "container-1",
+						Target: apiv1.ResourceList{
+							apiv1.ResourceCPU:                            resource.MustParse("1500m"),
+							apiv1.ResourceMemory:                         resource.MustParse("128Mi"),
+							apiv1.ResourceEphemeralStorage:               resource.MustParse("10Gi"),
+							apiv1.ResourceName("some.extended/resource"): resource.MustParse("4"),
+						},
+						LowerBound: apiv1.ResourceList{
+							apiv1.ResourceCPU:                            resource.MustParse("1200m"),
+							apiv1.ResourceMemory:                         resource.MustParse("96Mi"),
+							apiv1.ResourceEphemeralStorage:               resource.MustParse("8Gi"),
+							apiv1.ResourceName("some.extended/resource"): resource.MustParse("2"),
+						},
+						UpperBound: apiv1.ResourceList{
+							apiv1.ResourceCPU:                            resource.MustParse("1800m"),
+							apiv1.ResourceMemory:                         resource.MustParse("256Mi"),
+							apiv1.ResourceEphemeralStorage:               resource.MustParse("12Gi"),
+							apiv1.ResourceName("some.extended/resource"): resource.MustParse("6"),
+						},
+						UncappedTarget: apiv1.ResourceList{
+							apiv1.ResourceCPU:                            resource.MustParse("2500m"),
+							apiv1.ResourceMemory:                         resource.MustParse("1Gi"),
+							apiv1.ResourceEphemeralStorage:               resource.MustParse("20Gi"),
+							apiv1.ResourceName("some.extended/resource"): resource.MustParse("8"),
+						},
+					},
+				},
+			},
+			expectedRecommendation: vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					{
+						ContainerName: "container-1",
+						Target: apiv1.ResourceList{
+							apiv1.ResourceCPU:    resource.MustParse("1500m"),
+							apiv1.ResourceMemory: resource.MustParse("128Mi"),
+						},
+						LowerBound: apiv1.ResourceList{
+							apiv1.ResourceCPU:    resource.MustParse("1200m"),
+							apiv1.ResourceMemory: resource.MustParse("96Mi"),
+						},
+						UpperBound: apiv1.ResourceList{
+							apiv1.ResourceCPU:    resource.MustParse("1800m"),
+							apiv1.ResourceMemory: resource.MustParse("256Mi"),
+						},
+						UncappedTarget: apiv1.ResourceList{
+							apiv1.ResourceCPU:    resource.MustParse("2500m"),
+							apiv1.ResourceMemory: resource.MustParse("1Gi"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			processor := NewAllowedResourceFilter(tc.allowedResources)
+			processedRecommendation, _, err := processor.Apply(&tc.recommendation, &vpa_types.PodResourcePolicy{}, nil, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedRecommendation, *processedRecommendation)
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

This PR cherry-picks the necessary commits from our local fork onto the upstream vpa `1.0.0` (represented in our fork by `datadog-master-vpa-1.0.0`) in order to bring us closer with upstream.  The original list of commits was generated by [this diff](https://github.com/DataDog/autoscaler/compare/datadog-master-vpa-1.0.0...DataDog:autoscaler:vpa-0.13.0-dd.12), and then was filtered based on only the ones that we needed [here
](https://docs.google.com/document/d/1Ca8gGeM-eena4_ZrCilhpXsV24QdjEYBITtWnPsNv2E/edit?tab=t.0). 

I built a test image for this [here](https://gitlab.ddbuild.io/DataDog/images/-/pipelines/66017775) and rolled it out to snowver. Once this PR is merged I will create off of `datadog-master-vpa-1.0.0`, something like `vpa-1.0.0-dd1` and build an official image for that, and start the rollout!

A few other bits and pieces:
- I started a dashboard for the health of our VPA components: https://app.datadoghq.com/dashboard/kqa-usk-rf8?fromUser=false&refresh_mode=sliding&from_ts=1748026125039&to_ts=1748029725039&live=true
- I'm working on a doc to outline how to do this process moving forward. 

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
