### PR TITLE
Implemented HasInstance for GCE provider

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -108,9 +108,26 @@ func (gce *GceCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.N
 	return mig, err
 }
 
-// HasInstance returns whether a given node has a corresponding instance in this cloud provider
 func (gce *GceCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
-	return true, cloudprovider.ErrNotImplemented
+	ref, err := GceRefFromProviderId(node.Spec.ProviderID)
+	if err != nil {
+		return false, err
+	}
+
+	mig, err := gce.gceManager.GetMigForInstance(ref)
+	if err != nil {
+		return false, err
+	}
+
+	// Not managed by any registered MIG; there's not enough information to confidently say if this instance exists,
+	// so err on the side of safety and return an error. ErrNotImplemented is returned (vs. a generic error) to
+	// avoid repeated warning logging in clusterstate.
+	if mig == nil {
+		return true, cloudprovider.ErrNotImplemented
+	}
+
+	// Instance belongs to a managed MIG, so it's known to be backed by a live instance.
+	return true, nil
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available.


### PR DESCRIPTION
We encountered an issue where GCE pods drained by the cluster-autoscaler with long termination grace periods would get miscategorized by the CA upcoming nodes, which led to skipped scale up for legitmate pending workloads. This matched the behavior documented in #3949 and #4456, for which the HasInstance mechanism was implemented as a way to distinguish between actively deleting nodes and truly missing nodes.

This PR implements that behavior for the GCE provider, following general patterns from AWS and Azure. The implementation errs on the side of caution and only returns the instance exists if there is certainty from a MIG cache resolution of the instance ref; otherwise, it returns an error such that the behavior defaults to the current behavior of inspecting the nodes taints.
