### PR TITLE
[local] Allow larger expander requests

### DIFF
--- a/cluster-autoscaler/expander/grpcplugin/grpc_client.go
+++ b/cluster-autoscaler/expander/grpcplugin/grpc_client.go
@@ -33,8 +33,8 @@ import (
 )
 
 const (
-	gRPCTimeout        = 5 * time.Second
-	gRPCMaxRecvMsgSize = 128 << 20
+	gRPCTimeout        = 10 * time.Second
+	gRPCMaxRecvMsgSize = 512 << 20
 )
 
 type grpcclientstrategy struct {


### PR DESCRIPTION
128Mi is small in some circumstamce (for instance, large bursty jobs, when the gRPC requests might include many pods specs).
