### PR TITLE
Add provreq verbose lifecycle logging

### DIFF
--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -303,6 +303,8 @@ type AutoscalingOptions struct {
 	ProvisioningRequestMaxBackoffTime time.Duration
 	// ProvisioningRequestMaxCacheSize is the max size for ProvisioningRequest cache that is stored for retry backoff.
 	ProvisioningRequestMaxBackoffCacheSize int
+	// ProvisioningRequestVerboseLogging enables verbose lifecycle logging for ProvisioningRequest pods.
+	ProvisioningRequestVerboseLogging bool
 	// CheckCapacityBatchProcessing is used to enable/disable batch processing of check capacity provisioning class
 	CheckCapacityBatchProcessing bool
 	// CheckCapacityProvisioningRequestMaxBatchSize is the maximum number of provisioning requests to process in a single batch

--- a/cluster-autoscaler/config/flags/flags.go
+++ b/cluster-autoscaler/config/flags/flags.go
@@ -221,6 +221,7 @@ var (
 	asyncNodeGroupsEnabled                       = flag.Bool("async-node-groups", false, "Whether clusterautoscaler creates and deletes node groups asynchronously. Experimental: requires cloud provider supporting async node group operations, enable at your own risk.")
 	proactiveScaleupEnabled                      = flag.Bool("enable-proactive-scaleup", false, "Whether to enable/disable proactive scale-ups, defaults to false")
 	podInjectionLimit                            = flag.Int("pod-injection-limit", 5000, "Limits total number of pods while injecting fake pods. If unschedulable pods already exceeds the limit, pod injection is disabled but pods are not truncated.")
+	provisioningRequestVerboseLogging            = flag.Bool("provisioning-request-verbose-logging", false, "Whether to enable verbose lifecycle logging for ProvisioningRequest pods, useful for debugging scale-up/scale-down interactions.")
 	checkCapacityBatchProcessing                 = flag.Bool("check-capacity-batch-processing", false, "Whether to enable batch processing for check capacity requests.")
 	checkCapacityProvisioningRequestMaxBatchSize = flag.Int("check-capacity-provisioning-request-max-batch-size", 10, "Maximum number of provisioning requests to process in a single batch.")
 	checkCapacityProvisioningRequestBatchTimebox = flag.Duration("check-capacity-provisioning-request-batch-timebox", 10*time.Second, "Maximum time to process a batch of provisioning requests.")
@@ -395,6 +396,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		ProvisioningRequestInitialBackoffTime:        *provisioningRequestInitialBackoffTime,
 		ProvisioningRequestMaxBackoffTime:            *provisioningRequestMaxBackoffTime,
 		ProvisioningRequestMaxBackoffCacheSize:       *provisioningRequestMaxBackoffCacheSize,
+		ProvisioningRequestVerboseLogging:            *provisioningRequestVerboseLogging,
 		CheckCapacityBatchProcessing:                 *checkCapacityBatchProcessing,
 		CheckCapacityProvisioningRequestMaxBatchSize: *checkCapacityProvisioningRequestMaxBatchSize,
 		CheckCapacityProvisioningRequestBatchTimebox: *checkCapacityProvisioningRequestBatchTimebox,

--- a/cluster-autoscaler/core/scaledown/planner/planner.go
+++ b/cluster-autoscaler/core/scaledown/planner/planner.go
@@ -22,6 +22,7 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown"
@@ -268,6 +269,8 @@ func (p *Planner) injectPods(pods []*apiv1.Pod) error {
 func (p *Planner) categorizeNodes(podDestinations map[string]bool, scaleDownCandidates []*apiv1.Node) {
 	unremovableTimeout := p.latestUpdate.Add(p.context.AutoscalingOptions.UnremovableNodeRecheckTimeout)
 	unremovableCount := 0
+	provreqVerboseLogging := p.context.ProvisioningRequestVerboseLogging
+	provreqBlockedCount := 0
 	var removableList []simulator.NodeToBeRemoved
 	atomicScaleDownNodesCount := 0
 	p.unremovableNodes.Update(p.context.ClusterSnapshot, p.latestUpdate)
@@ -303,12 +306,20 @@ func (p *Planner) categorizeNodes(podDestinations map[string]bool, scaleDownCand
 		}
 		if unremovable != nil {
 			unremovableCount += 1
+			if provreqVerboseLogging && unremovable.BlockingPod != nil {
+				if _, ok := unremovable.BlockingPod.Pod.Annotations[v1.ProvisioningRequestPodAnnotationKey]; ok {
+					provreqBlockedCount++
+				}
+			}
 			p.unremovableNodes.AddTimeout(unremovable, unremovableTimeout)
 		}
 	}
 	p.unneededNodes.Update(removableList, p.latestUpdate)
 	if unremovableCount > 0 {
 		klog.V(1).Infof("%v nodes found to be unremovable in simulation, will re-check them at %v", unremovableCount, unremovableTimeout)
+	}
+	if provreqVerboseLogging && provreqBlockedCount > 0 {
+		klog.V(1).Infof("[provreq] %d node(s) unremovable due to provreq virtual pods blocking scale-down", provreqBlockedCount)
 	}
 }
 

--- a/cluster-autoscaler/processors/provreq/injector.go
+++ b/cluster-autoscaler/processors/provreq/injector.go
@@ -182,7 +182,7 @@ func (p *ProvisioningRequestPodsInjector) GetCheckCapacityBatch(maxPrs int) ([]P
 
 // Process pick one ProvisioningRequest, update Accepted condition and inject pods to unscheduled pods list.
 func (p *ProvisioningRequestPodsInjector) Process(
-	_ *context.AutoscalingContext,
+	ctx *context.AutoscalingContext,
 	unschedulablePods []*apiv1.Pod,
 ) ([]*apiv1.Pod, error) {
 	podsFromProvReq, err := p.GetPodsFromNextRequest()
@@ -190,6 +190,9 @@ func (p *ProvisioningRequestPodsInjector) Process(
 		return unschedulablePods, err
 	}
 
+	if ctx != nil && ctx.ProvisioningRequestVerboseLogging && len(podsFromProvReq) > 0 {
+		klog.Infof("[provreq] Injected %d virtual pod(s) from ProvisioningRequest into unschedulable pods list", len(podsFromProvReq))
+	}
 	return append(unschedulablePods, podsFromProvReq...), nil
 }
 

--- a/cluster-autoscaler/processors/provreq/processor.go
+++ b/cluster-autoscaler/processors/provreq/processor.go
@@ -160,6 +160,9 @@ func (p *provReqProcessor) bookCapacity(ctx *context.AutoscalingContext) error {
 			continue
 		}
 		podsToCreate = append(podsToCreate, pods...)
+		if ctx.ProvisioningRequestVerboseLogging {
+			klog.V(2).Infof("[provreq] Booking capacity: %d pod(s) for provreq_name=%s provreq_namespace=%s", len(pods), provReq.Name, provReq.Namespace)
+		}
 	}
 	if len(podsToCreate) == 0 {
 		return nil
@@ -167,6 +170,9 @@ func (p *provReqProcessor) bookCapacity(ctx *context.AutoscalingContext) error {
 	// Scheduling the pods to reserve capacity for provisioning request.
 	if _, _, err = p.injector.TrySchedulePods(ctx.ClusterSnapshot, podsToCreate, scheduling.ScheduleAnywhere, false); err != nil {
 		return err
+	}
+	if ctx.ProvisioningRequestVerboseLogging {
+		klog.Infof("[provreq] Capacity booked: %d total virtual pod(s) scheduled into cluster snapshot", len(podsToCreate))
 	}
 	return nil
 }

--- a/cluster-autoscaler/provisioningrequest/checkcapacity/provisioningclass.go
+++ b/cluster-autoscaler/provisioningrequest/checkcapacity/provisioningclass.go
@@ -177,6 +177,10 @@ func (o *checkCapacityProvClass) checkCapacity(unschedulablePods []*apiv1.Pod, p
 	// Case 1: Capacity fits.
 	scheduled, _, err := o.schedulingSimulator.TrySchedulePods(o.context.ClusterSnapshot, unschedulablePods, scheduling.ScheduleAnywhere, true)
 	if err == nil && len(scheduled) == len(unschedulablePods) {
+		if o.context.ProvisioningRequestVerboseLogging {
+			klog.Infof("[provreq] Check-capacity: capacity FOUND for provreq_name=%s provreq_namespace=%s pods_scheduled=%d",
+				provReq.Name, provReq.Namespace, len(scheduled))
+		}
 		commitError := o.context.ClusterSnapshot.Commit()
 		if commitError != nil {
 			o.context.ClusterSnapshot.Revert()
@@ -187,6 +191,10 @@ func (o *checkCapacityProvClass) checkCapacity(unschedulablePods []*apiv1.Pod, p
 		return nil
 	}
 	// Case 2: Capacity doesn't fit.
+	if o.context.ProvisioningRequestVerboseLogging {
+		klog.Infof("[provreq] Check-capacity: capacity NOT FOUND for provreq_name=%s provreq_namespace=%s pods_requested=%d pods_scheduled=%d",
+			provReq.Name, provReq.Namespace, len(unschedulablePods), len(scheduled))
+	}
 	o.context.ClusterSnapshot.Revert()
 	combinedStatus.Add(&status.ScaleUpStatus{Result: status.ScaleUpNoOptionsAvailable})
 	if noRetry, ok := provReq.Spec.Parameters[NoRetryParameterKey]; ok && noRetry == "true" {

--- a/cluster-autoscaler/provisioningrequest/orchestrator/wrapper_orchestrator.go
+++ b/cluster-autoscaler/provisioningrequest/orchestrator/wrapper_orchestrator.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
+	klog "k8s.io/klog/v2"
 )
 
 // WrapperOrchestrator is an orchestrator which wraps Scale Up for ProvisioningRequests and regular pods.
@@ -75,6 +76,10 @@ func (o *WrapperOrchestrator) ScaleUp(
 	}()
 
 	provReqPods, regularPods := splitOut(unschedulablePods)
+	verboseLog := o.autoscalingContext.ProvisioningRequestVerboseLogging
+	if verboseLog {
+		klog.V(2).Infof("[provreq] Scale-up split: %d provreq pod(s), %d regular pod(s)", len(provReqPods), len(regularPods))
+	}
 	if len(provReqPods) == 0 {
 		o.autoscalingContext.ProvisioningRequestScaleUpMode = false
 	} else if len(regularPods) == 0 {
@@ -82,7 +87,13 @@ func (o *WrapperOrchestrator) ScaleUp(
 	}
 
 	if o.autoscalingContext.ProvisioningRequestScaleUpMode {
+		if verboseLog {
+			klog.V(2).Infof("[provreq] Scale-up mode: processing provreq pods this iteration")
+		}
 		return o.provReqOrchestrator.ScaleUp(provReqPods, nodes, daemonSets, nodeInfos, allOrNothing)
+	}
+	if verboseLog {
+		klog.V(2).Infof("[provreq] Scale-up mode: processing regular pods this iteration")
 	}
 	return o.podsOrchestrator.ScaleUp(regularPods, nodes, daemonSets, nodeInfos, allOrNothing)
 }

--- a/cluster-autoscaler/simulator/cluster.go
+++ b/cluster-autoscaler/simulator/cluster.go
@@ -186,6 +186,15 @@ func (r *RemovalSimulator) SimulateNodeRemoval(
 	})
 	if err != nil {
 		klog.V(2).Infof("Node %s is not suitable for removal: %v", nodeName, err)
+		if r.deleteOptions.ProvisioningRequestVerboseLogging {
+			for _, pod := range podsToRemove {
+				if prName, ok := pod.Annotations[v1.ProvisioningRequestPodAnnotationKey]; ok {
+					provClass := pod.Annotations[v1.ProvisioningClassPodAnnotationKey]
+					klog.V(1).Infof("[provreq] Node %s unremovable (NoPlaceToMovePods): virtual pod=%s/%s provreq_name=%s provisioning_class=%s cannot be rescheduled",
+						nodeName, pod.Namespace, pod.Name, prName, provClass)
+				}
+			}
+		}
 		return nil, &UnremovableNode{Node: nodeInfo.Node(), Reason: NoPlaceToMovePods}
 	}
 	klog.V(2).Infof("Node %s may be removed", nodeName)

--- a/cluster-autoscaler/simulator/cluster.go
+++ b/cluster-autoscaler/simulator/cluster.go
@@ -23,6 +23,7 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/pdb"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability/rules"
@@ -168,6 +169,13 @@ func (r *RemovalSimulator) SimulateNodeRemoval(
 	if err != nil {
 		klog.V(2).Infof("Node %s cannot be removed: %v", nodeName, err)
 		if blockingPod != nil {
+			if r.deleteOptions.ProvisioningRequestVerboseLogging {
+				if prName, ok := blockingPod.Pod.Annotations[v1.ProvisioningRequestPodAnnotationKey]; ok {
+					provClass := blockingPod.Pod.Annotations[v1.ProvisioningClassPodAnnotationKey]
+					klog.V(1).Infof("[provreq] Node %s unremovable: blocked by virtual pod=%s/%s provreq_name=%s provisioning_class=%s blocking_reason=%s",
+						nodeName, blockingPod.Pod.Namespace, blockingPod.Pod.Name, prName, provClass, blockingPod.Reason)
+				}
+			}
 			return nil, &UnremovableNode{Node: nodeInfo.Node(), Reason: BlockedByPod, BlockingPod: blockingPod}
 		}
 		return nil, &UnremovableNode{Node: nodeInfo.Node(), Reason: UnexpectedError}

--- a/cluster-autoscaler/simulator/drain.go
+++ b/cluster-autoscaler/simulator/drain.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	apiv1 "k8s.io/api/core/v1"
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/pdb"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability/rules"
@@ -28,6 +29,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/utils/drain"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	pod_util "k8s.io/autoscaler/cluster-autoscaler/utils/pod"
+	klog "k8s.io/klog/v2"
 )
 
 // GetPodsToMove returns a list of pods that should be moved elsewhere and a
@@ -61,6 +63,13 @@ func GetPodsToMove(nodeInfo *framework.NodeInfo, deleteOptions options.NodeDelet
 				pods = append(pods, pod)
 			}
 		case drainability.BlockDrain:
+			if deleteOptions.ProvisioningRequestVerboseLogging {
+				if prName, ok := pod.Annotations[v1.ProvisioningRequestPodAnnotationKey]; ok {
+					provClass := pod.Annotations[v1.ProvisioningClassPodAnnotationKey]
+					klog.V(2).Infof("[provreq] Virtual pod blocking node drain: pod=%s/%s provreq_name=%s provisioning_class=%s blocking_reason=%s node=%s",
+						pod.Namespace, pod.Name, prName, provClass, status.BlockingReason, nodeInfo.Node().Name)
+				}
+			}
 			return nil, nil, &drain.BlockingPod{
 				Pod:    pod,
 				Reason: status.BlockingReason,

--- a/cluster-autoscaler/simulator/options/nodedelete.go
+++ b/cluster-autoscaler/simulator/options/nodedelete.go
@@ -40,6 +40,8 @@ type NodeDeleteOptions struct {
 	// BspDisruptionTimeout is the timeout after which CA will evict
 	// non-pdb-assigned blocking system pods
 	BspDisruptionTimeout time.Duration
+	// ProvisioningRequestVerboseLogging enables verbose lifecycle logging for ProvisioningRequest pods.
+	ProvisioningRequestVerboseLogging bool
 }
 
 // NewNodeDeleteOptions returns new node delete options extracted from autoscaling options.
@@ -50,5 +52,6 @@ func NewNodeDeleteOptions(opts config.AutoscalingOptions) NodeDeleteOptions {
 		SkipNodesWithCustomControllerPods: opts.SkipNodesWithCustomControllerPods,
 		MinReplicaCount:                   opts.MinReplicaCount,
 		BspDisruptionTimeout:              opts.BspDisruptionTimeout,
+		ProvisioningRequestVerboseLogging: opts.ProvisioningRequestVerboseLogging,
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `--provisioning-request-verbose-logging` flag (default: `false`) to gate `[provreq]`-prefixed logs across the full ProvisioningRequest pod lifecycle
- Covers 7 log sites: injection, scale-up split, check-capacity result, capacity booking, drain blocking, node unremovable, and summary count
- All logs use consistent `[provreq]` prefix for easy Datadog log filtering and facet extraction (`provreq_name`, `provisioning_class`, `blocking_reason`, `node`)

## How provreq virtual pods block scale-down

  Provisioned ProvReq virtual pods are booked into the cluster snapshot by bookCapacity() to reserve capacity. These pods can block node scale-down in two ways:

  1. `NotReplicated` drain block: The virtual pods have OwnerReference.Kind: "ProvisioningRequest" which is not in the replicatedKind map (replicated/rule.go). With `--skip-nodes-with-custom-controller-pods=true`, the replicated drain rule immediately blocks the node as `NotReplicated`.
  2. `NoPlaceToMovePods` reschedule block: Even with `--skip-nodes-with-custom-controller-pods=false` (so the controllerRef passes the replicated check since it's non-nil), the scale-down simulation still calls `findPlaceFor()` which attempts to reschedule the virtual pods to other nodes. If there isn't enough capacity elsewhere in the cluster to accommodate them, the node is blocked with `NoPlaceToMovePods`.

  Previously there was zero provreq-specific logging for either case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)