### PR TITLE
[local][hack] force zone labels to be lower case

### DIFF
--- a/cluster-autoscaler/cloudprovider/oci/instancepools/oci_instance_pool_cache.go
+++ b/cluster-autoscaler/cloudprovider/oci/instancepools/oci_instance_pool_cache.go
@@ -294,7 +294,7 @@ func (c *instancePoolCache) findInstanceByDetails(ociInstance ocicommon.OciRef) 
 					ociInstance.InstanceID = *poolMember.Id
 					ociInstance.InstancePoolID = *nextInstancePool.Id
 					ociInstance.CompartmentID = *poolMember.CompartmentId
-					ociInstance.AvailabilityDomain = strings.Split(*poolMember.AvailabilityDomain, ":")[1]
+					ociInstance.AvailabilityDomain = strings.ToLower(strings.Split(*poolMember.AvailabilityDomain, ":")[1])
 					ociInstance.Shape = *poolMember.Shape
 					ociInstance.PrivateIPAddress = *getVnicResp.Vnic.PrivateIp
 					// Public IP is optional

--- a/cluster-autoscaler/cloudprovider/oci/instancepools/oci_instance_pool_manager.go
+++ b/cluster-autoscaler/cloudprovider/oci/instancepools/oci_instance_pool_manager.go
@@ -699,6 +699,6 @@ func getInstancePoolAvailabilityDomain(ip *core.InstancePool) (string, error) {
 
 	// Get the availability domain which is by default in the format of `Uocm:PHX-AD-1`
 	// and remove the hash prefix.
-	availabilityDomain := strings.Split(*ip.PlacementConfigurations[0].AvailabilityDomain, ":")[1]
+	availabilityDomain := strings.ToLower(strings.Split(*ip.PlacementConfigurations[0].AvailabilityDomain, ":")[1])
 	return availabilityDomain, nil
 }

--- a/cluster-autoscaler/cloudprovider/oci/instancepools/oci_instance_pool_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/oci/instancepools/oci_instance_pool_manager_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -477,7 +478,7 @@ func TestGetInstancePoolAvailabilityDomain(t *testing.T) {
 				}},
 				Size: common.Int(2),
 			},
-			result: "US-ASHBURN-1",
+			result: strings.ToLower("US-ASHBURN-1"),
 		},
 		"multi-ad": {
 			np: &core.InstancePool{
@@ -492,7 +493,7 @@ func TestGetInstancePoolAvailabilityDomain(t *testing.T) {
 				}},
 				Size: common.Int(2),
 			},
-			result: "US-ASHBURN-1",
+			result: strings.ToLower("US-ASHBURN-1"),
 		},
 	}
 
@@ -638,7 +639,7 @@ func TestGetInstancePoolTemplateNode(t *testing.T) {
 	}
 
 	// Also check the AD label for good measure.
-	if got := labels[apiv1.LabelTopologyZone]; got != "US-ASHBURN-1" {
+	if got := labels[apiv1.LabelTopologyZone]; got != strings.ToLower("US-ASHBURN-1") {
 		t.Fatalf("expected AD zone label %s to be set to US-ASHBURN-1: %v", apiv1.LabelTopologyZone, nodeTemplate.Labels)
 	}
 


### PR DESCRIPTION
For now, hardcode the labels used for identifying zone to call strings.ToLower on the returned value. OCIs APIs are inconsistent in whether they return mixed case or lower case (varies by API), and we prefer all lower case for consistency. CCM is behaving similarly



