### PR TITLE
[local] Treat 'local-data-block' Storage Class in the same way as 'local-data'

### DIFF
--- a/cluster-autoscaler/processors/datadog/pods/transform_local_data.go
+++ b/cluster-autoscaler/processors/datadog/pods/transform_local_data.go
@@ -69,6 +69,11 @@ import (
 	klog "k8s.io/klog/v2"
 )
 
+var localDataStorageClasses = map[string]struct{}{
+	"local-data":       {},
+	"local-data-block": {},
+}
+
 type transformLocalData struct {
 	pvcLister   v1lister.PersistentVolumeClaimLister
 	stopChannel chan struct{}
@@ -124,7 +129,7 @@ func (p *transformLocalData) Process(ctx *context.AutoscalingContext, pods []*ap
 				volumes = append(volumes, vol)
 				continue
 			}
-			if *pvc.Spec.StorageClassName != "local-data" {
+			if _, ok := localDataStorageClasses[*pvc.Spec.StorageClassName]; !ok {
 				volumes = append(volumes, vol)
 				continue
 			}

--- a/cluster-autoscaler/processors/datadog/pods/transform_local_data_test.go
+++ b/cluster-autoscaler/processors/datadog/pods/transform_local_data_test.go
@@ -36,6 +36,7 @@ import (
 var (
 	testRemoteClass        = "remote-data"
 	testLocalClass         = "local-data"
+	testLocalBlockClass    = "local-data-block"
 	testNamespace          = "foons"
 	testEmptyResources     = corev1.ResourceList{}
 	testDefaultLdResources = corev1.ResourceList{
@@ -92,6 +93,32 @@ func TestTransformLocalDataProcess(t *testing.T) {
 				buildPVC("pvc-1", testRemoteClass),
 				buildPVC("pvc-2", testLocalClass),
 				buildPVC("pvc-3", testRemoteClass),
+			},
+			[]*corev1.Pod{buildPod("pod1", testDefaultLdResources, testDefaultLdResources, "pvc-1", "pvc-3")},
+		},
+
+		{
+			"local-data-block volumes are removed, and custom resources added with default storage",
+			[]*corev1.Pod{buildPod("pod1", testEmptyResources, testEmptyResources, "pvc-1")},
+			[]*corev1.PersistentVolumeClaim{buildPVC("pvc-1", testLocalBlockClass)},
+			[]*corev1.Pod{buildPod("pod1", testDefaultLdResources, testDefaultLdResources)},
+		},
+
+		{
+			"local-data-block volumes are removed, and custom resources added with local storage capacity",
+			[]*corev1.Pod{buildPod("pod1", testEmptyResources, testEmptyResources, "pvc-1")},
+			[]*corev1.PersistentVolumeClaim{buildPVCWithStorage("pvc-1", testLocalBlockClass, localStorage)},
+			[]*corev1.Pod{buildPod("pod1", testLdResources, testLdResources)},
+		},
+
+		{
+			"mixed local-data, local-data-block and remote volumes don't cause confusion",
+			[]*corev1.Pod{buildPod("pod1", testEmptyResources, testEmptyResources, "pvc-1", "pvc-2", "pvc-3", "pvc-4")},
+			[]*corev1.PersistentVolumeClaim{
+				buildPVC("pvc-1", testRemoteClass),
+				buildPVC("pvc-2", testLocalClass),
+				buildPVC("pvc-3", testRemoteClass),
+				buildPVC("pvc-4", testLocalBlockClass),
 			},
 			[]*corev1.Pod{buildPod("pod1", testDefaultLdResources, testDefaultLdResources, "pvc-1", "pvc-3")},
 		},


### PR DESCRIPTION
# Description

Follow-up to https://github.com/DataDog/k8s-platform-resources/pull/22746

Right now the CA is not able to scale-up NodeGroups where pods request `local-data-block` StorageClass PVs. This PR fixes that by ensuring that `local-data-block` is treated in the same way as the regular `local-data`. 