### PR TITLE
[local] AWS DRA: build template ResourceSlices for GPU scale-from-zero

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws-dra-gpu-config-example.yaml
+++ b/cluster-autoscaler/cloudprovider/aws/aws-dra-gpu-config-example.yaml
@@ -1,0 +1,130 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-autoscaler-aws-dra-gpu-config
+  namespace: kube-system
+data:
+  # Phase 1 (full-GPU): one entry per EC2 GpuInfo short name, mirrors the attributes the
+  # real NVIDIA DRA driver publishes via NVML at runtime (productName/brand/architecture/
+  # cudaComputeCapability). An instance type whose short name is absent still gets a
+  # ResourceSlice with type=gpu and memory capacity, just without the richer attributes.
+  # memoryMiB is optional and overrides EC2's reported per-device memory when the driver's
+  # actual published capacity differs (e.g. reserved memory) — see RTX PRO Server 6000 below,
+  # where EC2 reports 98304MiB but the driver's verified capacity is 95Gi/97280MiB.
+  full-gpu-attributes.yaml: |
+    A10G:
+      productName: "NVIDIA A10G"
+      brand: "Nvidia"
+      architecture: "Ampere"
+      cudaComputeCapability: "8.6.0"
+    H100:
+      productName: "NVIDIA H100 80GB HBM3"
+      brand: "Nvidia"
+      architecture: "Hopper"
+      cudaComputeCapability: "9.0.0"
+    RTX PRO Server 6000:
+      productName: "NVIDIA RTX PRO 6000 Blackwell Server Edition"
+      brand: "Nvidia"
+      architecture: "Blackwell"
+      cudaComputeCapability: "12.0.0"
+      memoryMiB: 97280
+
+  # Phase 2 (MIG): one entry per EC2 GpuInfo short name -> list of memory variants of that
+  # model. Each variant lists the whole-GPU engine/memory budget and the plain MIG profiles
+  # (name/profileID/memorySlices/placements/engines) the driver publishes for it. Values
+  # below are transcribed from real driver-published ResourceSlices (`kubectl get
+  # resourceslice -o json`) for RTX PRO Server 6000; the A100 entry is an UNVERIFIED
+  # placeholder pending a real capture.
+  mig-profile-tables.yaml: |
+    RTX PRO Server 6000:
+      - gpuMemoryMiB: 98304
+        productName: "NVIDIA RTX PRO 6000 Blackwell Server Edition"
+        brand: "Nvidia"
+        architecture: "Blackwell"
+        cudaComputeCapability: "12.0.0"
+        memorySlices: 12
+        whole: {multiprocessors: 188, copyEngines: 4, decoders: 4, encoders: 4, jpegEngines: 4, ofaEngines: 1, memory: "95Gi"}
+        profiles:
+          - name: "1g.24gb"
+            profileID: 14
+            memorySlices: 3
+            placements: [0, 3, 6, 9]
+            engines: {multiprocessors: 46, copyEngines: 1, decoders: 1, encoders: 1, jpegEngines: 1, ofaEngines: 0, memory: "24192Mi"}
+          - name: "2g.48gb"
+            profileID: 5
+            memorySlices: 6
+            placements: [0, 6]
+            engines: {multiprocessors: 94, copyEngines: 2, decoders: 2, encoders: 2, jpegEngines: 2, ofaEngines: 0, memory: "48512Mi"}
+          - name: "4g.96gb"
+            profileID: 0
+            memorySlices: 12
+            placements: [0]
+            engines: {multiprocessors: 188, copyEngines: 4, decoders: 4, encoders: 4, jpegEngines: 4, ofaEngines: 1, memory: "95Gi"}
+    H100:
+      - gpuMemoryMiB: 81152
+        productName: "NVIDIA H100 80GB HBM3"
+        brand: "Nvidia"
+        architecture: "Hopper"
+        cudaComputeCapability: "9.0.0"
+        memorySlices: 8
+        whole: {multiprocessors: 132, copyEngines: 8, decoders: 7, encoders: 0, jpegEngines: 7, ofaEngines: 1, memory: "81152Mi"}
+        profiles:
+          - name: "1g.10gb"
+            profileID: 19
+            memorySlices: 1
+            placements: [0, 1, 2, 3, 4, 5, 6]
+            engines: {multiprocessors: 16, copyEngines: 1, decoders: 1, encoders: 0, jpegEngines: 1, ofaEngines: 0, memory: "9984Mi"}
+          - name: "1g.20gb"
+            profileID: 15
+            memorySlices: 2
+            placements: [0, 2, 4, 6]
+            engines: {multiprocessors: 26, copyEngines: 1, decoders: 1, encoders: 0, jpegEngines: 1, ofaEngines: 0, memory: "20096Mi"}
+          - name: "2g.20gb"
+            profileID: 14
+            memorySlices: 2
+            placements: [0, 2, 4]
+            engines: {multiprocessors: 32, copyEngines: 2, decoders: 2, encoders: 0, jpegEngines: 2, ofaEngines: 0, memory: "20096Mi"}
+          - name: "3g.40gb"
+            profileID: 9
+            memorySlices: 4
+            placements: [0, 4]
+            engines: {multiprocessors: 60, copyEngines: 3, decoders: 3, encoders: 0, jpegEngines: 3, ofaEngines: 0, memory: "40448Mi"}
+          - name: "4g.40gb"
+            profileID: 5
+            memorySlices: 4
+            placements: [0]
+            engines: {multiprocessors: 64, copyEngines: 4, decoders: 4, encoders: 0, jpegEngines: 4, ofaEngines: 0, memory: "40448Mi"}
+          - name: "7g.80gb"
+            profileID: 0
+            memorySlices: 8
+            placements: [0]
+            engines: {multiprocessors: 132, copyEngines: 8, decoders: 7, encoders: 0, jpegEngines: 7, ofaEngines: 1, memory: "81152Mi"}
+    A100:
+      - gpuMemoryMiB: 40960
+        productName: "NVIDIA A100-SXM4-40GB"
+        brand: "Nvidia"
+        architecture: "Ampere"
+        cudaComputeCapability: "8.0.0"
+        memorySlices: 8
+        whole: {multiprocessors: 108, copyEngines: 7, decoders: 5, encoders: 0, jpegEngines: 1, ofaEngines: 1, memory: "40Gi"}
+        profiles:
+          - name: "1g.5gb"
+            profileID: 19
+            memorySlices: 1
+            placements: [0, 1, 2, 3, 4, 5, 6]
+            engines: {multiprocessors: 14, copyEngines: 1, memory: "5Gi"}
+          - name: "2g.10gb"
+            profileID: 14
+            memorySlices: 2
+            placements: [0, 2, 4]
+            engines: {multiprocessors: 28, copyEngines: 2, decoders: 1, memory: "10Gi"}
+          - name: "3g.20gb"
+            profileID: 9
+            memorySlices: 4
+            placements: [0, 4]
+            engines: {multiprocessors: 42, copyEngines: 3, decoders: 2, memory: "20Gi"}
+          - name: "7g.40gb"
+            profileID: 0
+            memorySlices: 8
+            placements: [0]
+            engines: {multiprocessors: 98, copyEngines: 7, decoders: 5, jpegEngines: 1, ofaEngines: 1, memory: "40Gi"}

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -420,7 +420,8 @@ func (ng *AwsNodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
 		return nil, err
 	}
 
-	nodeInfo := framework.NewNodeInfo(node, nil, framework.NewPodInfo(cloudprovider.BuildKubeProxy(ng.asg.Name), nil))
+	resourceSlices := buildResourceSlicesFromTemplate(node, template.InstanceType)
+	nodeInfo := framework.NewNodeInfo(node, resourceSlices, framework.NewPodInfo(cloudprovider.BuildKubeProxy(ng.asg.Name), nil))
 	return nodeInfo, nil
 }
 
@@ -477,6 +478,8 @@ func BuildAWS(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDis
 	if err != nil {
 		klog.Fatalf("Failed to create AWS Manager: %v", err)
 	}
+
+	initDraGPUDataSource(opts) // see aws_dra_config.go; sets up the ConfigMap-backed GPU/MIG data source used by aws_dra.go/aws_dra_mig.go
 
 	provider, err := BuildAwsCloudProvider(manager, rl)
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/aws/aws_dra.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_dra.go
@@ -1,0 +1,182 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"fmt"
+
+	apiv1 "k8s.io/api/core/v1"
+	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	klog "k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+)
+
+// Dynamic Resource Allocation (DRA) scale-from-zero support for GPU node groups.
+//
+// Cluster Autoscaler cannot make correct scale-from-zero decisions for pods that
+// use DRA ResourceClaims (e.g. GPU requests via DRA), because TemplateNodeInfo()
+// builds a template node with no ResourceSlices attached. During scale-up the DRA
+// scheduler plugin then finds no device inventory to allocate the claim against and
+// concludes the node group cannot help the pod, so it never scales up.
+//
+// This file fabricates the ResourceSlices that the NVIDIA DRA driver would publish
+// once the node boots, derived from the EC2 instance type's GPU metadata plus GPU
+// attribute data read from a ConfigMap (see aws_dra_config.go, draGPUDataSource). The
+// slices are attached to the template node so the scheduler's simulation can allocate
+// the claim and trigger scale-up.
+//
+// Nothing here is intended for upstream: this is a Datadog-specific way of keeping GPU
+// attribute data operator-editable without a CA rebuild/redeploy.
+
+const (
+	// draDriverLabelKey opts a node group into DRA ResourceSlice generation and names
+	// the DRA driver the fabricated slices belong to (e.g. "gpu.nvidia.com"). It is set
+	// as a node label on the node group's kubelet labels and reaches the template node
+	// via the node-template/label ASG tag path (extractLabelsFromAsg).
+	draDriverLabelKey = "node.datadoghq.com/dra-driver"
+
+	// draMIGEnabledLabelKey marks a node group as MIG-enabled. When set to "true", the
+	// builder emits MIG profile-placement devices plus counter sets instead of a single
+	// full-GPU device. See aws_dra_mig.go.
+	draMIGEnabledLabelKey = "node.datadoghq.com/dra-mig-enabled"
+
+	// gpuDeviceType is the value of the "type" device attribute, matching what the
+	// NVIDIA DRA driver emits at runtime.
+	gpuDeviceType = "gpu"
+)
+
+// GPU attribute data, keyed on the EC2 GpuInfo short name (InstanceType.GPUShortName), is
+// read from a ConfigMap at runtime via draGPUDataSource (see aws_dra_config.go) rather than
+// compiled into the binary. EC2 only exposes the short name (e.g. "A10G", "H100") and
+// per-device memory; every other attribute the NVIDIA driver publishes via NVML at runtime
+// must be reproduced in the ConfigMap so CEL selectors on those attributes evaluate
+// correctly during scale-up simulation. An instance type whose short name is absent from
+// the ConfigMap still gets a ResourceSlice with type=gpu and memory capacity, just without
+// the richer attributes.
+
+// buildResourceSlicesFromTemplate fabricates the DRA ResourceSlices for a template node,
+// reproducing what the NVIDIA DRA driver would publish on the real node. It returns nil
+// for node groups that are not DRA-enabled or have no GPUs, leaving non-DRA behaviour
+// unchanged.
+func buildResourceSlicesFromTemplate(node *apiv1.Node, instanceType *InstanceType) []*resourceapi.ResourceSlice {
+	if node == nil || instanceType == nil {
+		return nil
+	}
+	driver := node.Labels[draDriverLabelKey]
+	if driver == "" || instanceType.GPU == 0 {
+		return nil
+	}
+
+	// Log the observed GPU short name so the correct ConfigMap key can be discovered from
+	// CA logs (EC2 short names are not always known ahead of time).
+	klog.V(4).Infof("DRA: building ResourceSlices for node group GPU %q (%s, driver %s)", instanceType.GPUShortName, instanceType.InstanceType, driver)
+
+	// GPUShortName/GPUMemoryMiB are populated only via the dynamic EC2 API path
+	// (aws_util.go), never by the static instance-type list (--aws-use-static-instance-list),
+	// so this combination means the operator is running that mode.
+	//
+	// Two options here: warn and keep going with a degraded full-GPU slice (current behavior),
+	// or fail safe and return nil like the "unknown SKU"/no-MIG-table paths do. We warn rather
+	// than suppress because the degraded slice is still useful for the common case: a claim
+	// selecting only on type=gpu (no attribute/memory constraint) is satisfied correctly by it,
+	// and static-instance-list is chosen specifically for private/airgapped clusters where the
+	// EC2 API isn't reachable at all — silently returning nil there would make DRA scale-from-
+	// zero permanently non-functional for every GPU node group with no operator-visible cause
+	// beyond this log line. A claim that does constrain on attributes or memory won't match
+	// during simulation either way (missing vs. wrong), so nothing is lost by not suppressing.
+	if instanceType.GPUShortName == "" && instanceType.GPUMemoryMiB == 0 {
+		klog.Warningf("DRA enabled for node group with GPU instance type %s but GPUShortName/GPUMemoryMiB are unset (likely --aws-use-static-instance-list); fabricated ResourceSlices will be missing attributes and MIG groups will get none", instanceType.InstanceType)
+	}
+
+	// MIG-enabled node groups advertise partitionable devices (see aws_dra_mig.go).
+	if node.Labels[draMIGEnabledLabelKey] == "true" {
+		return buildMIGResourceSlices(node, instanceType, driver)
+	}
+
+	return buildFullGPUResourceSlices(node, instanceType, driver)
+}
+
+// buildFullGPUResourceSlices builds one ResourceSlice per physical GPU (the Phase 1,
+// non-MIG path). The driver emits one slice per GPU, each carrying one device.
+func buildFullGPUResourceSlices(node *apiv1.Node, instanceType *InstanceType, driver string) []*resourceapi.ResourceSlice {
+	nodeName := node.Name
+	fullAttrs, ok := gpuDataSource.fullGPUAttributes(instanceType.GPUShortName)
+	attrs := gpuDeviceAttributes(fullAttrs, ok)
+
+	// MemoryMiB, when set, is the driver-verified capacity for this GPU model; EC2's nominal
+	// GPUMemoryMiB can overstate what the driver actually publishes (see fullGPUAttrs.MemoryMiB).
+	memoryMiB := instanceType.GPUMemoryMiB
+	if ok && fullAttrs.MemoryMiB > 0 {
+		memoryMiB = fullAttrs.MemoryMiB
+	}
+	var capacity map[resourceapi.QualifiedName]resourceapi.DeviceCapacity
+	if memoryMiB > 0 {
+		capacity = map[resourceapi.QualifiedName]resourceapi.DeviceCapacity{
+			"memory": {Value: resource.MustParse(fmt.Sprintf("%dMi", memoryMiB))},
+		}
+	}
+
+	totalSlices := instanceType.GPU // one slice per GPU
+	slices := make([]*resourceapi.ResourceSlice, 0, int(instanceType.GPU))
+	for i := int64(0); i < instanceType.GPU; i++ {
+		slices = append(slices, &resourceapi.ResourceSlice{
+			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-%s-%d", nodeName, driver, i)},
+			Spec: resourceapi.ResourceSliceSpec{
+				Driver:   driver,
+				NodeName: &nodeName,
+				Pool:     resourceapi.ResourcePool{Name: nodeName, ResourceSliceCount: totalSlices},
+				Devices: []resourceapi.Device{{
+					Name:       fmt.Sprintf("gpu-%d", i),
+					Attributes: attrs,
+					Capacity:   capacity,
+				}},
+			},
+		})
+	}
+	return slices
+}
+
+// gpuDeviceAttributes returns the device attributes for a GPU short name's looked-up
+// fullGPUAttrs. "type" is always present; the richer attributes are added only when found is
+// true (the short name is known to the ConfigMap-backed data source, see aws_dra_config.go,
+// gpuDataSource). Runtime-only attributes the driver publishes from NVML/sysfs
+// (driverVersion, cudaDriverVersion, uuid, pciBusID, pcieRoot, addressingMode) are
+// deliberately omitted — they cannot be known pre-scale, so CEL selectors referencing them
+// will not match template slices.
+func gpuDeviceAttributes(a fullGPUAttrs, found bool) map[resourceapi.QualifiedName]resourceapi.DeviceAttribute {
+	attrs := map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+		"type": {StringValue: ptr.To(gpuDeviceType)},
+	}
+	if !found {
+		return attrs
+	}
+	if a.ProductName != "" {
+		attrs["productName"] = resourceapi.DeviceAttribute{StringValue: ptr.To(a.ProductName)}
+	}
+	if a.Brand != "" {
+		attrs["brand"] = resourceapi.DeviceAttribute{StringValue: ptr.To(a.Brand)}
+	}
+	if a.Architecture != "" {
+		attrs["architecture"] = resourceapi.DeviceAttribute{StringValue: ptr.To(a.Architecture)}
+	}
+	if a.CudaComputeCapability != "" {
+		attrs["cudaComputeCapability"] = resourceapi.DeviceAttribute{VersionValue: ptr.To(a.CudaComputeCapability)}
+	}
+	return attrs
+}

--- a/cluster-autoscaler/cloudprovider/aws/aws_dra_config.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_dra_config.go
@@ -1,0 +1,208 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"fmt"
+	"sync"
+
+	apiv1 "k8s.io/api/core/v1"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
+	v1lister "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/record"
+	klog "k8s.io/klog/v2"
+	"sigs.k8s.io/yaml"
+)
+
+// ConfigMap-backed alternative to the hardcoded GPU/MIG attribute maps in aws_dra.go and
+// aws_dra_mig.go. Instead of compiling GPU capability data into the binary, this reads it
+// from a ConfigMap so an operator can add a GPU model or fix a wrong MIG placement table by
+// editing the ConfigMap, with no CA rebuild/redeploy.
+//
+// Follows the same pattern as the priority expander (expander/priority/priority.go): a
+// lightweight client-go Reflector/Indexer-backed lister (utils/kubernetes.
+// NewConfigMapListerForNamespace), no persistent parsed cache — every call re-reads the
+// local watch-cache and re-parses the YAML — and a fail-safe fallback (log + not-found,
+// never a crash) on any error. The lister's background watch means an edited ConfigMap
+// takes effect on the very next call, typically within a second or two, not up to the
+// hourly resync period.
+
+const (
+	// gpuConfigMapName is the ConfigMap holding GPU/MIG capability data, read from the
+	// namespace CA itself runs in (opts.ConfigNamespace).
+	gpuConfigMapName = "cluster-autoscaler-aws-dra-gpu-config"
+	// fullGPUAttributesKey holds the Phase-1 (full-GPU) attribute map, one entry per EC2 GPU
+	// short name. Mirrors gpuFullProductName/gpuBrand/gpuArchitecture/gpuCudaComputeCapability.
+	fullGPUAttributesKey = "full-gpu-attributes.yaml"
+	// migProfileTablesKey holds the Phase-2 (MIG) profile tables, one-to-one with the
+	// hardcoded migProfileTables shape (short name -> list of memory variants).
+	migProfileTablesKey = "mig-profile-tables.yaml"
+)
+
+// draGPUDataSource abstracts where Phase-1/Phase-2 GPU capability data comes from, so
+// aws_dra.go/aws_dra_mig.go don't care whether it's compiled-in or ConfigMap-backed.
+type draGPUDataSource interface {
+	// fullGPUAttributes returns the full-GPU device attributes for an EC2 GPU short name.
+	fullGPUAttributes(shortName string) (fullGPUAttrs, bool)
+	// migVariants returns the MIG memory-variant table for an EC2 GPU short name.
+	migVariants(shortName string) ([]migVariant, bool)
+}
+
+// fullGPUAttrs is the Phase-1 device-attribute set for one GPU short name. Fields are
+// optional (empty string = attribute omitted), matching today's per-map independent lookups.
+type fullGPUAttrs struct {
+	ProductName           string `json:"productName,omitempty"`
+	Brand                 string `json:"brand,omitempty"`
+	Architecture          string `json:"architecture,omitempty"`
+	CudaComputeCapability string `json:"cudaComputeCapability,omitempty"`
+	// MemoryMiB overrides EC2's reported per-device GPU memory for the full-GPU capacity, for
+	// GPU models where EC2's nominal figure differs from what the driver actually publishes
+	// (e.g. reserved memory) — see the RTX PRO Server 6000 MIG table's whole.memory for a
+	// verified example of this gap. Zero/omitted falls back to instanceType.GPUMemoryMiB.
+	MemoryMiB int64 `json:"memoryMiB,omitempty"`
+}
+
+// configMapGPUDataSource is the real draGPUDataSource, backed by a ConfigMap.
+type configMapGPUDataSource struct {
+	configMapLister v1lister.ConfigMapNamespaceLister
+	logRecorder     record.EventRecorder
+	// lastWarned dedupes logWarning by (cm.ResourceVersion, msg): buildResourceSlicesFromTemplate
+	// runs once per DRA-enabled node group per CA loop tick, so a persistently broken
+	// ConfigMap would otherwise re-emit an Event + log line indefinitely, every tick, forever.
+	lastWarned map[string]string
+	warnMu     sync.Mutex
+}
+
+// newConfigMapGPUDataSource constructs a configMapGPUDataSource. logRecorder may be nil
+// (e.g. in tests), in which case only klog warnings are emitted, no k8s Events.
+func newConfigMapGPUDataSource(lister v1lister.ConfigMapNamespaceLister, logRecorder record.EventRecorder) *configMapGPUDataSource {
+	return &configMapGPUDataSource{configMapLister: lister, logRecorder: logRecorder, lastWarned: map[string]string{}}
+}
+
+// logWarning emits an Event + klog warning for msg under key, but only once per distinct
+// (key, cm.ResourceVersion, msg) combination — re-evaluating the same broken ConfigMap on
+// every call does not re-log until the ConfigMap actually changes.
+func (s *configMapGPUDataSource) logWarning(cm *apiv1.ConfigMap, key, reason, msg string) {
+	resourceVersion := ""
+	if cm != nil {
+		resourceVersion = cm.ResourceVersion
+	}
+	dedupeKey := key + "@" + resourceVersion
+
+	s.warnMu.Lock()
+	alreadyWarned := s.lastWarned[dedupeKey] == msg
+	if !alreadyWarned {
+		s.lastWarned[dedupeKey] = msg
+	}
+	s.warnMu.Unlock()
+	if alreadyWarned {
+		return
+	}
+
+	if s.logRecorder != nil && cm != nil {
+		s.logRecorder.Event(cm, apiv1.EventTypeWarning, reason, msg)
+	}
+	klog.Warning(msg)
+}
+
+func (s *configMapGPUDataSource) fullGPUAttributes(shortName string) (fullGPUAttrs, bool) {
+	cm, err := s.configMapLister.Get(gpuConfigMapName)
+	if err != nil {
+		s.logWarning(nil, "not-found:"+fullGPUAttributesKey, "AwsDraGpuConfigNotFound", fmt.Sprintf("DRA GPU config map %s not found: %v", gpuConfigMapName, err))
+		return fullGPUAttrs{}, false
+	}
+	raw, found := cm.Data[fullGPUAttributesKey]
+	if !found {
+		s.logWarning(cm, fullGPUAttributesKey, "AwsDraGpuConfigInvalid", fmt.Sprintf("DRA GPU config map %s missing key %s; ignoring", gpuConfigMapName, fullGPUAttributesKey))
+		return fullGPUAttrs{}, false
+	}
+	var attrs map[string]fullGPUAttrs
+	if err := yaml.Unmarshal([]byte(raw), &attrs); err != nil {
+		s.logWarning(cm, fullGPUAttributesKey, "AwsDraGpuConfigInvalid", fmt.Sprintf("DRA GPU config map %s key %s: %v; ignoring", gpuConfigMapName, fullGPUAttributesKey, err))
+		return fullGPUAttrs{}, false
+	}
+	a, ok := attrs[shortName]
+	return a, ok
+}
+
+func (s *configMapGPUDataSource) migVariants(shortName string) ([]migVariant, bool) {
+	cm, err := s.configMapLister.Get(gpuConfigMapName)
+	if err != nil {
+		s.logWarning(nil, "not-found:"+migProfileTablesKey, "AwsDraGpuConfigNotFound", fmt.Sprintf("DRA GPU config map %s not found: %v", gpuConfigMapName, err))
+		return nil, false
+	}
+	raw, found := cm.Data[migProfileTablesKey]
+	if !found {
+		s.logWarning(cm, migProfileTablesKey, "AwsDraGpuConfigInvalid", fmt.Sprintf("DRA GPU config map %s missing key %s; ignoring", gpuConfigMapName, migProfileTablesKey))
+		return nil, false
+	}
+	var tables map[string][]migVariant
+	if err := yaml.Unmarshal([]byte(raw), &tables); err != nil {
+		s.logWarning(cm, migProfileTablesKey, "AwsDraGpuConfigInvalid", fmt.Sprintf("DRA GPU config map %s key %s: %v; ignoring", gpuConfigMapName, migProfileTablesKey, err))
+		return nil, false
+	}
+	rawVariants, ok := tables[shortName]
+	if !ok {
+		return nil, false
+	}
+	variants := make([]migVariant, 0, len(rawVariants))
+	for i, v := range rawVariants {
+		if err := v.validate(); err != nil {
+			s.logWarning(cm, fmt.Sprintf("%s:%s:%d", migProfileTablesKey, shortName, i), "AwsDraGpuConfigInvalid", fmt.Sprintf("DRA GPU config map %s key %s: shortname %q variant %d: %v; skipping", gpuConfigMapName, migProfileTablesKey, shortName, i, err))
+			continue
+		}
+		variants = append(variants, v)
+	}
+	if len(variants) == 0 {
+		return nil, false
+	}
+	return variants, true
+}
+
+// noopGPUDataSource is used when no Kubernetes client is available to build a ConfigMap
+// lister (e.g. some test/CLI paths); it always reports not-found, matching today's
+// fail-safe behaviour for an unmapped GPU short name.
+type noopGPUDataSource struct{}
+
+func (noopGPUDataSource) fullGPUAttributes(string) (fullGPUAttrs, bool) { return fullGPUAttrs{}, false }
+func (noopGPUDataSource) migVariants(string) ([]migVariant, bool)       { return nil, false }
+
+// gpuDataSource is the process-wide source of GPU/MIG capability data consulted by
+// aws_dra.go/aws_dra_mig.go. Defaults to noopGPUDataSource (fail-safe: no fabrication for
+// any GPU short name) until initDraGPUDataSource runs; there is exactly one AWS cloud
+// provider per process, so this mirrors the existing single-init pattern used elsewhere in
+// this package (e.g. RegisterMetrics in aws_cloud_provider.go) rather than needing to be
+// threaded through AwsManager/AwsNodeGroup as an explicit dependency.
+var gpuDataSource draGPUDataSource = noopGPUDataSource{}
+
+// initDraGPUDataSource wires up the ConfigMap-backed gpuDataSource from BuildAWS. Falls
+// back to leaving gpuDataSource as the noop default if no KubeClient is available (e.g.
+// some test/CLI paths), matching today's fail-safe behaviour for an unmapped GPU short name.
+func initDraGPUDataSource(opts *coreoptions.AutoscalerOptions) {
+	if opts.KubeClient == nil {
+		klog.Warningf("DRA GPU ConfigMap data source disabled: no KubeClient available")
+		return
+	}
+	var recorder record.EventRecorder
+	if opts.AutoscalingKubeClients != nil {
+		recorder = opts.AutoscalingKubeClients.Recorder
+	}
+	stopChannel := make(chan struct{}) // never closed, mirrors expander/factory's ConfigMap lister setup
+	cmLister := kubernetes.NewConfigMapListerForNamespace(opts.KubeClient, stopChannel, opts.ConfigNamespace)
+	gpuDataSource = newConfigMapGPUDataSource(cmLister.ConfigMaps(opts.ConfigNamespace), recorder)
+}

--- a/cluster-autoscaler/cloudprovider/aws/aws_dra_config_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_dra_config_test.go
@@ -1,0 +1,306 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"os"
+	"testing"
+
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1lister "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/yaml"
+)
+
+// TestMain seeds the package-level gpuDataSource with a fixture before any test runs, so
+// aws_dra_test.go/aws_dra_mig_allocator_test.go's calls to buildResourceSlicesFromTemplate/
+// buildMIGResourceSlices (unchanged from the hardcoded-map branch — no explicit data-source
+// parameter) exercise the same values the old compiled-in maps carried.
+func TestMain(m *testing.M) {
+	gpuDataSource = testGPUDataSource()
+	os.Exit(m.Run())
+}
+
+// fakeGPUDataSource is an in-memory draGPUDataSource test double, used both as the TestMain
+// fixture above and directly by the ConfigMap-lister tests below.
+type fakeGPUDataSource struct {
+	attrs map[string]fullGPUAttrs
+	migs  map[string][]migVariant
+}
+
+func (f fakeGPUDataSource) fullGPUAttributes(shortName string) (fullGPUAttrs, bool) {
+	a, ok := f.attrs[shortName]
+	return a, ok
+}
+
+func (f fakeGPUDataSource) migVariants(shortName string) ([]migVariant, bool) {
+	v, ok := f.migs[shortName]
+	return v, ok
+}
+
+// testGPUDataSource returns a fixture with the same literal values the hardcoded maps
+// used to carry, covering every GPU short name the existing tests exercise. B200 and L4 are
+// deliberately absent from their respective tables so the "unknown SKU" tests still cover
+// the not-found fallback path.
+func testGPUDataSource() fakeGPUDataSource {
+	return fakeGPUDataSource{
+		attrs: map[string]fullGPUAttrs{
+			"A10G": {ProductName: "NVIDIA A10G", Brand: "Nvidia", Architecture: "Ampere", CudaComputeCapability: "8.6.0"},
+			"H100": {ProductName: "NVIDIA H100 80GB HBM3", Brand: "Nvidia", Architecture: "Hopper", CudaComputeCapability: "9.0.0"},
+		},
+		migs: map[string][]migVariant{
+			// VERIFIED: NVIDIA RTX PRO 6000 Blackwell Server Edition (AWS g7e).
+			rtxPro6000ShortName: {{
+				GPUMemoryMiB:          98304,
+				ProductName:           "NVIDIA RTX PRO 6000 Blackwell Server Edition",
+				Brand:                 "Nvidia",
+				Architecture:          "Blackwell",
+				CudaComputeCapability: "12.0.0",
+				MemorySlices:          12,
+				Whole:                 engineCounts{Multiprocessors: 188, CopyEngines: 4, Decoders: 4, Encoders: 4, JPEGEngines: 4, OFAEngines: 1, Memory: "95Gi"},
+				Profiles: []migProfile{
+					{Name: "1g.24gb", ProfileID: 14, MemorySlices: 3, Placements: []int{0, 3, 6, 9}, Engines: engineCounts{Multiprocessors: 46, CopyEngines: 1, Decoders: 1, Encoders: 1, JPEGEngines: 1, OFAEngines: 0, Memory: "24192Mi"}},
+					{Name: "2g.48gb", ProfileID: 5, MemorySlices: 6, Placements: []int{0, 6}, Engines: engineCounts{Multiprocessors: 94, CopyEngines: 2, Decoders: 2, Encoders: 2, JPEGEngines: 2, OFAEngines: 0, Memory: "48512Mi"}},
+					{Name: "4g.96gb", ProfileID: 0, MemorySlices: 12, Placements: []int{0}, Engines: engineCounts{Multiprocessors: 188, CopyEngines: 4, Decoders: 4, Encoders: 4, JPEGEngines: 4, OFAEngines: 1, Memory: "95Gi"}},
+				},
+			}},
+			// UNVERIFIED: NVIDIA A100 (AWS p4d/p4de). Placeholder structure.
+			"A100": {{
+				GPUMemoryMiB:          40960,
+				ProductName:           "NVIDIA A100-SXM4-40GB",
+				Brand:                 "Nvidia",
+				Architecture:          "Ampere",
+				CudaComputeCapability: "8.0.0",
+				MemorySlices:          8,
+				Whole:                 engineCounts{Multiprocessors: 108, CopyEngines: 7, Decoders: 5, Encoders: 0, JPEGEngines: 1, OFAEngines: 1, Memory: "40Gi"},
+				Profiles: []migProfile{
+					{Name: "1g.5gb", ProfileID: 19, MemorySlices: 1, Placements: []int{0, 1, 2, 3, 4, 5, 6}, Engines: engineCounts{Multiprocessors: 14, CopyEngines: 1, Memory: "5Gi"}},
+					{Name: "2g.10gb", ProfileID: 14, MemorySlices: 2, Placements: []int{0, 2, 4}, Engines: engineCounts{Multiprocessors: 28, CopyEngines: 2, Decoders: 1, Memory: "10Gi"}},
+					{Name: "3g.20gb", ProfileID: 9, MemorySlices: 4, Placements: []int{0, 4}, Engines: engineCounts{Multiprocessors: 42, CopyEngines: 3, Decoders: 2, Memory: "20Gi"}},
+					{Name: "7g.40gb", ProfileID: 0, MemorySlices: 8, Placements: []int{0}, Engines: engineCounts{Multiprocessors: 98, CopyEngines: 7, Decoders: 5, JPEGEngines: 1, OFAEngines: 1, Memory: "40Gi"}},
+				},
+			}},
+		},
+	}
+}
+
+// newTestConfigMapLister builds a v1lister.ConfigMapNamespaceLister seeded directly from an
+// indexer (no reflector/watch), for tests that exercise configMapGPUDataSource itself.
+func newTestConfigMapLister(t *testing.T, namespace string, cms ...*apiv1.ConfigMap) v1lister.ConfigMapNamespaceLister {
+	t.Helper()
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	for _, cm := range cms {
+		if err := indexer.Add(cm); err != nil {
+			t.Fatalf("failed to seed fake configmap indexer: %v", err)
+		}
+	}
+	return v1lister.NewConfigMapLister(indexer).ConfigMaps(namespace)
+}
+
+func testConfigMap(namespace string, data map[string]string) *apiv1.ConfigMap {
+	return &apiv1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: gpuConfigMapName, Namespace: namespace},
+		Data:       data,
+	}
+}
+
+func TestConfigMapGPUDataSource_MissingConfigMap(t *testing.T) {
+	src := newConfigMapGPUDataSource(newTestConfigMapLister(t, "kube-system"), nil)
+
+	_, ok := src.fullGPUAttributes("A10G")
+	if ok {
+		t.Fatal("expected not-found when the ConfigMap doesn't exist")
+	}
+	if _, ok := src.migVariants(rtxPro6000ShortName); ok {
+		t.Fatal("expected not-found when the ConfigMap doesn't exist")
+	}
+}
+
+func TestConfigMapGPUDataSource_MissingKey(t *testing.T) {
+	cm := testConfigMap("kube-system", map[string]string{"unrelated-key": "value"})
+	src := newConfigMapGPUDataSource(newTestConfigMapLister(t, "kube-system", cm), nil)
+
+	if _, ok := src.fullGPUAttributes("A10G"); ok {
+		t.Fatal("expected not-found when full-gpu-attributes.yaml key is missing")
+	}
+	if _, ok := src.migVariants(rtxPro6000ShortName); ok {
+		t.Fatal("expected not-found when mig-profile-tables.yaml key is missing")
+	}
+}
+
+func TestConfigMapGPUDataSource_MalformedYAML(t *testing.T) {
+	cm := testConfigMap("kube-system", map[string]string{
+		fullGPUAttributesKey: "not: valid: yaml: [",
+		migProfileTablesKey:  "not: valid: yaml: [",
+	})
+	src := newConfigMapGPUDataSource(newTestConfigMapLister(t, "kube-system", cm), nil)
+
+	if _, ok := src.fullGPUAttributes("A10G"); ok {
+		t.Fatal("expected not-found for malformed YAML")
+	}
+	if _, ok := src.migVariants(rtxPro6000ShortName); ok {
+		t.Fatal("expected not-found for malformed YAML")
+	}
+}
+
+func TestConfigMapGPUDataSource_ShortNameMiss(t *testing.T) {
+	cm := testConfigMap("kube-system", map[string]string{
+		fullGPUAttributesKey: "A10G:\n  productName: NVIDIA A10G\n",
+		migProfileTablesKey:  "A100: []\n",
+	})
+	src := newConfigMapGPUDataSource(newTestConfigMapLister(t, "kube-system", cm), nil)
+
+	if _, ok := src.fullGPUAttributes("H100"); ok {
+		t.Fatal("expected not-found for a shortname absent from the parsed data")
+	}
+	if _, ok := src.migVariants("H100"); ok {
+		t.Fatal("expected not-found for a shortname absent from the parsed data")
+	}
+}
+
+// TestConfigMapGPUDataSource_InvalidQuantity checks that a variant with an unparseable or
+// non-positive quantity is dropped rather than reaching aws_dra_mig.go's resource.MustParse,
+// which would panic on a bad string; a sibling valid variant for the same short name must
+// still be returned.
+func TestConfigMapGPUDataSource_InvalidQuantity(t *testing.T) {
+	migYAML := `
+A100:
+  - gpuMemoryMiB: 40960
+    productName: "bad whole memory"
+    brand: "Nvidia"
+    architecture: "Ampere"
+    memorySlices: 1
+    whole: {memory: "not-a-quantity"}
+    profiles: []
+  - gpuMemoryMiB: 0
+    productName: "non-positive gpuMemoryMiB"
+    brand: "Nvidia"
+    architecture: "Ampere"
+    memorySlices: 1
+    whole: {memory: "40Gi"}
+    profiles: []
+  - gpuMemoryMiB: 80000
+    productName: "bad profile engines.memory"
+    brand: "Nvidia"
+    architecture: "Ampere"
+    memorySlices: 1
+    whole: {memory: "80Gi"}
+    profiles:
+      - name: "1g.10gb"
+        profileID: 0
+        memorySlices: 1
+        placements: [0]
+        engines: {memory: "also-not-a-quantity"}
+  - gpuMemoryMiB: 40960
+    productName: "the only valid variant"
+    brand: "Nvidia"
+    architecture: "Ampere"
+    memorySlices: 1
+    whole: {memory: "40Gi"}
+    profiles: []
+`
+	cm := testConfigMap("kube-system", map[string]string{migProfileTablesKey: migYAML})
+	src := newConfigMapGPUDataSource(newTestConfigMapLister(t, "kube-system", cm), nil)
+
+	got, ok := src.migVariants("A100")
+	if !ok {
+		t.Fatal("expected the one valid variant to still be returned")
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d variants, want 1 (the three invalid ones should be dropped): %+v", len(got), got)
+	}
+	if got[0].ProductName != "the only valid variant" {
+		t.Fatalf("got variant %+v, want the valid one to survive", got[0])
+	}
+}
+
+// TestConfigMapGPUDataSource_AllVariantsInvalid checks the not-found fallback when every
+// variant for a short name fails validation, rather than returning an empty-but-ok slice.
+func TestConfigMapGPUDataSource_AllVariantsInvalid(t *testing.T) {
+	migYAML := `
+A100:
+  - gpuMemoryMiB: 40960
+    productName: "bad whole memory"
+    brand: "Nvidia"
+    architecture: "Ampere"
+    memorySlices: 1
+    whole: {memory: "not-a-quantity"}
+    profiles: []
+`
+	cm := testConfigMap("kube-system", map[string]string{migProfileTablesKey: migYAML})
+	src := newConfigMapGPUDataSource(newTestConfigMapLister(t, "kube-system", cm), nil)
+
+	if _, ok := src.migVariants("A100"); ok {
+		t.Fatal("expected not-found when every variant for the short name is invalid")
+	}
+}
+
+// TestConfigMapGPUDataSource_HappyPath round-trips a realistic RTX-6000-shaped YAML blob
+// through the ConfigMap parser and checks it snapshot-equals the hardcoded fixture value —
+// a regression guard that the YAML schema and the Go mapper stay consistent.
+func TestConfigMapGPUDataSource_HappyPath(t *testing.T) {
+	migYAML := `
+RTX PRO Server 6000:
+  - gpuMemoryMiB: 98304
+    productName: "NVIDIA RTX PRO 6000 Blackwell Server Edition"
+    brand: "Nvidia"
+    architecture: "Blackwell"
+    cudaComputeCapability: "12.0.0"
+    memorySlices: 12
+    whole: {multiprocessors: 188, copyEngines: 4, decoders: 4, encoders: 4, jpegEngines: 4, ofaEngines: 1, memory: "95Gi"}
+    profiles:
+      - name: "1g.24gb"
+        profileID: 14
+        memorySlices: 3
+        placements: [0, 3, 6, 9]
+        engines: {multiprocessors: 46, copyEngines: 1, decoders: 1, encoders: 1, jpegEngines: 1, ofaEngines: 0, memory: "24192Mi"}
+      - name: "2g.48gb"
+        profileID: 5
+        memorySlices: 6
+        placements: [0, 6]
+        engines: {multiprocessors: 94, copyEngines: 2, decoders: 2, encoders: 2, jpegEngines: 2, ofaEngines: 0, memory: "48512Mi"}
+      - name: "4g.96gb"
+        profileID: 0
+        memorySlices: 12
+        placements: [0]
+        engines: {multiprocessors: 188, copyEngines: 4, decoders: 4, encoders: 4, jpegEngines: 4, ofaEngines: 1, memory: "95Gi"}
+`
+	// Sanity-check the YAML itself parses into the expected internal type before comparing.
+	var tables map[string][]migVariant
+	if err := yaml.Unmarshal([]byte(migYAML), &tables); err != nil {
+		t.Fatalf("failed to parse fixture YAML: %v", err)
+	}
+
+	cm := testConfigMap("kube-system", map[string]string{migProfileTablesKey: migYAML})
+	src := newConfigMapGPUDataSource(newTestConfigMapLister(t, "kube-system", cm), nil)
+
+	got, ok := src.migVariants(rtxPro6000ShortName)
+	if !ok {
+		t.Fatal("expected the RTX PRO Server 6000 entry to be found")
+	}
+	want := testGPUDataSource().migs[rtxPro6000ShortName]
+	if len(got) != len(want) {
+		t.Fatalf("got %d variants, want %d", len(got), len(want))
+	}
+	if got[0].ProductName != want[0].ProductName || got[0].MemorySlices != want[0].MemorySlices {
+		t.Fatalf("parsed variant doesn't match fixture: got %+v, want %+v", got[0], want[0])
+	}
+	if len(got[0].Profiles) != len(want[0].Profiles) {
+		t.Fatalf("got %d profiles, want %d", len(got[0].Profiles), len(want[0].Profiles))
+	}
+}

--- a/cluster-autoscaler/cloudprovider/aws/aws_dra_mig.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_dra_mig.go
@@ -1,0 +1,401 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"fmt"
+
+	apiv1 "k8s.io/api/core/v1"
+	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	klog "k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+)
+
+// MIG (Multi-Instance GPU) scale-from-zero support, the Phase 2 extension of aws_dra.go.
+//
+// A MIG-capable GPU can be carved into isolated partitions ("profiles"); with dynamic MIG
+// + DRA the NVIDIA driver reconfigures partitions per-pod at schedule time, so one
+// MIG-enabled node group replaces the combinatorial explosion of per-profile node groups.
+// For scale-from-zero the scheduler must be able to allocate a MIG ResourceClaim against
+// the template node, so this file reproduces the partitionable-device ResourceSlices the
+// driver publishes at runtime (KEP-4815).
+//
+// SHAPE (verified against a real RTX PRO 6000 Blackwell g7e node):
+//
+//   - one counters slice: SharedCounters, one CounterSet per physical GPU, no devices
+//   - one devices slice PER physical GPU: the whole-GPU device plus every MIG
+//     (profile x placement), each with ConsumesCounters referencing its GPU's CounterSet
+//
+// So a node with G GPUs yields 1 + G ResourceSlices, all sharing (Driver, Pool.Name).
+//
+// Two counter-name conventions, both verbatim from the driver: CounterSet / ConsumesCounters
+// use hyphenated names (copy-engines), while device Capacity uses camelCase (copyEngines).
+//
+// The tables are read from a ConfigMap at runtime (see aws_dra_config.go,
+// draGPUDataSource), populated from a real node's published ResourceSlice (capture with
+// `kubectl get resourceslice -o json`) rather than compiled into the binary — see
+// draGPUDataSource.migVariants. Only the plain profiles are modelled — the driver also
+// publishes +gfx/+me/+me.all media/graphics variants, which are omitted here (a claim for
+// a plain profile does not need them).
+
+const (
+	// migProfileAttr is the device attribute carrying the MIG profile name (e.g. "1g.24gb").
+	// It is a bare (driver-domain) attribute name, matching what the driver emits and what
+	// claim CEL selects on: device.attributes['gpu.nvidia.com'].profile.
+	migProfileAttr = "profile"
+	// migDeviceType is the value of the "type" attribute on a MIG device (whole-GPU devices
+	// use gpuDeviceType = "gpu").
+	migDeviceType = "mig"
+
+	// Counter names for CounterSet / ConsumesCounters (hyphenated, verbatim from the driver).
+	ctrCopyEngines           = "copy-engines"
+	ctrDecoders              = "decoders"
+	ctrEncoders              = "encoders"
+	ctrJPEGEngines           = "jpeg-engines"
+	ctrOFAEngines            = "ofa-engines"
+	ctrMemory                = "memory"
+	ctrMultiprocessors       = "multiprocessors"
+	memorySliceCounterPrefix = "memory-slice-"
+
+	// Capacity names on devices (camelCase, verbatim from the driver).
+	capCopyEngines     = "copyEngines"
+	capDecoders        = "decoders"
+	capEncoders        = "encoders"
+	capJPEGEngines     = "jpegEngines"
+	capOFAEngines      = "ofaEngines"
+	capMemory          = "memory"
+	capMultiprocessors = "multiprocessors"
+
+	// rtxPro6000ShortName is the EC2 GpuInfo short name for the NVIDIA RTX PRO Server 6000
+	// Blackwell (g7e instance family), as returned by DescribeInstanceTypes.
+	rtxPro6000ShortName = "RTX PRO Server 6000"
+)
+
+// engineCounts is the per-device hardware-unit budget shared by a device's capacity and its
+// counter consumption (a MIG device statically consumes exactly what it exposes). Fields are
+// exported with JSON/YAML tags so this same type is both the internal representation used
+// throughout this file AND the ConfigMap-unmarshal target (see aws_dra_config.go) — no
+// separate mirror struct/converter layer.
+type engineCounts struct {
+	Multiprocessors int64  `json:"multiprocessors,omitempty"`
+	CopyEngines     int64  `json:"copyEngines,omitempty"`
+	Decoders        int64  `json:"decoders,omitempty"`
+	Encoders        int64  `json:"encoders,omitempty"`
+	JPEGEngines     int64  `json:"jpegEngines,omitempty"`
+	OFAEngines      int64  `json:"ofaEngines,omitempty"`
+	Memory          string `json:"memory,omitempty"` // resource.Quantity string, e.g. "24192Mi" or "95Gi"
+}
+
+// migProfile is one MIG profile and where it may be placed on the GPU's memory slices.
+type migProfile struct {
+	Name         string       `json:"name"`         // bare profile attribute value, e.g. "1g.24gb"
+	ProfileID    int          `json:"profileID"`    // NVML profile id, used only in the device name
+	MemorySlices int          `json:"memorySlices"` // contiguous memory slices the profile occupies
+	Placements   []int        `json:"placements"`   // valid starting memory-slice offsets; one device per placement
+	Engines      engineCounts `json:"engines"`
+}
+
+// migVariant is one memory variant of a GPU model: its whole-GPU budget, identity
+// attributes, and available profiles. Selected by matching EC2 per-device GPU memory.
+type migVariant struct {
+	GPUMemoryMiB          int64        `json:"gpuMemoryMiB"` // matches EC2 GpuInfo memory; see selectMIGVariant
+	ProductName           string       `json:"productName"`
+	Brand                 string       `json:"brand"`
+	Architecture          string       `json:"architecture"`
+	CudaComputeCapability string       `json:"cudaComputeCapability,omitempty"` // NVML version string, e.g. "12.0.0"
+	MemorySlices          int          `json:"memorySlices"`                    // total memory slices on the GPU
+	Whole                 engineCounts `json:"whole"`
+	Profiles              []migProfile `json:"profiles"`
+}
+
+// validate checks every resource.Quantity string an operator can supply in the ConfigMap
+// before it reaches this file's resource.MustParse calls, which panic on an invalid quantity.
+// A variant failing validation is dropped entirely rather than partially applied (see
+// aws_dra_config.go, configMapGPUDataSource.migVariants).
+func (v migVariant) validate() error {
+	if v.GPUMemoryMiB <= 0 {
+		return fmt.Errorf("gpuMemoryMiB must be positive, got %d", v.GPUMemoryMiB)
+	}
+	if _, err := resource.ParseQuantity(v.Whole.Memory); err != nil {
+		return fmt.Errorf("whole.memory %q: %w", v.Whole.Memory, err)
+	}
+	for i, p := range v.Profiles {
+		if _, err := resource.ParseQuantity(p.Engines.Memory); err != nil {
+			return fmt.Errorf("profiles[%d] (%s) engines.memory %q: %w", i, p.Name, p.Engines.Memory, err)
+		}
+	}
+	return nil
+}
+
+// migVariantMatchToleranceFraction bounds how far a variant's gpuMemoryMiB may diverge from
+// EC2's reported per-device memory (as a fraction of the variant's memory) and still be
+// treated as the same physical SKU — e.g. the RTX PRO Server 6000's EC2-reported 98304MiB
+// vs. its driver-verified "whole.memory" of 95Gi/97280MiB is a real, observed ~1% gap. A flat
+// MiB tolerance doesn't generalize across GPU memory scales, so this is proportional, with a
+// floor for small-memory GPUs where a flat percentage would be too tight.
+const (
+	migVariantMatchToleranceFraction = 0.02 // 2%, double the largest gap observed so far
+	migVariantMatchToleranceFloorMiB = 1024
+)
+
+// migVariantMatchTolerance returns the max acceptable |EC2 memory - variant memory| delta for
+// a variant with the given gpuMemoryMiB. It deliberately rejects picking, say, a 40GiB A100
+// variant for an 80GiB A100 instance: a wrong variant advertises the wrong
+// profiles/placements/capacities and can pass a claim CA cannot satisfy.
+func migVariantMatchTolerance(variantGPUMemoryMiB int64) int64 {
+	tolerance := int64(float64(variantGPUMemoryMiB) * migVariantMatchToleranceFraction)
+	if tolerance < migVariantMatchToleranceFloorMiB {
+		return migVariantMatchToleranceFloorMiB
+	}
+	return tolerance
+}
+
+// selectMIGVariant picks the variant of a GPU model whose per-device memory matches EC2's
+// report within migVariantMatchTolerance. Returns false if the model has no MIG table in the
+// ConfigMap-backed data source, or no variant is close enough to trust (see aws_dra_config.go,
+// gpuDataSource; today's ConfigMap ships VERIFIED tables for RTX PRO 6000 and H100,
+// transcribed from real nodes' published ResourceSlices, and an UNVERIFIED placeholder for
+// A100).
+func selectMIGVariant(shortName string, gpuMemoryMiB int64) (migVariant, bool) {
+	variants, ok := gpuDataSource.migVariants(shortName)
+	if !ok || len(variants) == 0 {
+		return migVariant{}, false
+	}
+	memoryDelta := func(v migVariant) int64 {
+		delta := v.GPUMemoryMiB - gpuMemoryMiB
+		if delta < 0 {
+			return -delta
+		}
+		return delta
+	}
+	best := variants[0]
+	bestDelta := memoryDelta(variants[0])
+	for _, v := range variants[1:] {
+		if delta := memoryDelta(v); delta < bestDelta {
+			best, bestDelta = v, delta
+		}
+	}
+	if bestDelta > migVariantMatchTolerance(best.GPUMemoryMiB) {
+		return migVariant{}, false
+	}
+	return best, true
+}
+
+// buildMIGResourceSlices builds the counters slice plus one devices slice per GPU for a
+// MIG-enabled node group, matching the real driver's shape. Returns nil if the SKU has no
+// MIG table (so the node group fails safe rather than advertising a bogus inventory).
+//
+// A single physical GPU's devices are split across multiple ResourceSlices if they exceed
+// resourceapi.ResourceSliceMaxDevices (128) — the API rejects a slice over that limit. No known
+// NVIDIA MIG GPU today has anywhere near 128 (profile x placement) devices on one physical GPU
+// (H100, the densest table here, has 18), so this is defensive rather than reachable with
+// today's hardware; it's here so a future denser MIG geometry fails a k8s API validation error
+// at slice-creation time on the real node rather than silently producing an invalid template.
+func buildMIGResourceSlices(node *apiv1.Node, instanceType *InstanceType, driver string) []*resourceapi.ResourceSlice {
+	v, ok := selectMIGVariant(instanceType.GPUShortName, instanceType.GPUMemoryMiB)
+	if !ok {
+		klog.Warningf("DRA MIG enabled for node group with GPU %q but no MIG profile table exists; not advertising MIG ResourceSlices for %s", instanceType.GPUShortName, node.Name)
+		return nil
+	}
+
+	nodeName := node.Name
+	gpuCount := int(instanceType.GPU)
+
+	perGPUDevices := make([][]resourceapi.Device, gpuCount)
+	for g := 0; g < gpuCount; g++ {
+		devices := []resourceapi.Device{wholeGPUDevice(g, v)}
+		for _, p := range v.Profiles {
+			for _, start := range p.Placements {
+				devices = append(devices, migDevice(g, v, p, start))
+			}
+		}
+		perGPUDevices[g] = devices
+	}
+
+	totalSlices := int64(1) // counters slice
+	for _, devices := range perGPUDevices {
+		totalSlices += int64(deviceChunkCount(len(devices)))
+	}
+	slices := make([]*resourceapi.ResourceSlice, 0, totalSlices)
+
+	counters := &resourceapi.ResourceSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-%s-counters", nodeName, driver)},
+		Spec:       newSliceSpec(driver, nodeName, totalSlices),
+	}
+	for g := 0; g < gpuCount; g++ {
+		counters.Spec.SharedCounters = append(counters.Spec.SharedCounters, counterSetForGPU(counterSetName(g), v))
+	}
+	slices = append(slices, counters)
+
+	for g, devices := range perGPUDevices {
+		for chunkIndex, chunk := range chunkDevices(devices) {
+			spec := newSliceSpec(driver, nodeName, totalSlices)
+			spec.Devices = chunk
+			slices = append(slices, &resourceapi.ResourceSlice{
+				ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-%s-devices-%d-%d", nodeName, driver, g, chunkIndex)},
+				Spec:       spec,
+			})
+		}
+	}
+	return slices
+}
+
+// deviceChunkCount returns how many resourceapi.ResourceSliceMaxDevices-sized ResourceSlices n
+// devices need.
+func deviceChunkCount(n int) int {
+	return (n + resourceapi.ResourceSliceMaxDevices - 1) / resourceapi.ResourceSliceMaxDevices
+}
+
+// chunkDevices splits devices into resourceapi.ResourceSliceMaxDevices-sized slices.
+func chunkDevices(devices []resourceapi.Device) [][]resourceapi.Device {
+	var chunks [][]resourceapi.Device
+	for len(devices) > 0 {
+		n := min(len(devices), resourceapi.ResourceSliceMaxDevices)
+		chunks = append(chunks, devices[:n])
+		devices = devices[n:]
+	}
+	return chunks
+}
+
+func newSliceSpec(driver, nodeName string, totalSliceCount int64) resourceapi.ResourceSliceSpec {
+	nn := nodeName
+	return resourceapi.ResourceSliceSpec{
+		Driver:   driver,
+		NodeName: &nn,
+		Pool:     resourceapi.ResourcePool{Name: nodeName, ResourceSliceCount: totalSliceCount},
+	}
+}
+
+func counterSetName(gpuIndex int) string {
+	return fmt.Sprintf("gpu-%d-counter-set", gpuIndex)
+}
+
+// counterSetForGPU builds one physical GPU's divisible budget: one counter per memory slice
+// plus the bulk memory and hardware-unit totals.
+func counterSetForGPU(name string, v migVariant) resourceapi.CounterSet {
+	counters := engineCountersHyphen(v.Whole)
+	for s := 0; s < v.MemorySlices; s++ {
+		counters[fmt.Sprintf("%s%d", memorySliceCounterPrefix, s)] = counterQty(1)
+	}
+	return resourceapi.CounterSet{Name: name, Counters: counters}
+}
+
+// wholeGPUDevice is the full-GPU device the driver publishes even in MIG mode; it consumes
+// every counter, so allocating it excludes all MIG partitions and vice versa.
+func wholeGPUDevice(gpuIndex int, v migVariant) resourceapi.Device {
+	consumed := engineCountersHyphen(v.Whole)
+	for s := 0; s < v.MemorySlices; s++ {
+		consumed[fmt.Sprintf("%s%d", memorySliceCounterPrefix, s)] = counterQty(1)
+	}
+	return resourceapi.Device{
+		Name:       fmt.Sprintf("gpu-%d", gpuIndex),
+		Attributes: gpuIdentityAttributes(v, gpuDeviceType, ""),
+		Capacity:   engineCapacity(v.Whole),
+		ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+			{CounterSet: counterSetName(gpuIndex), Counters: consumed},
+		},
+	}
+}
+
+// migDevice is one (profile x placement) partition on a GPU. It consumes the contiguous
+// memory-slice span [start, start+memorySlices) plus its engine share, which is how the
+// scheduler enforces non-overlap.
+func migDevice(gpuIndex int, v migVariant, p migProfile, start int) resourceapi.Device {
+	consumed := engineCountersHyphen(p.Engines)
+	for s := start; s < start+p.MemorySlices; s++ {
+		consumed[fmt.Sprintf("%s%d", memorySliceCounterPrefix, s)] = counterQty(1)
+	}
+	return resourceapi.Device{
+		Name:       fmt.Sprintf("gpu-%d-mig-%s-%d-%d", gpuIndex, sanitizeProfileName(p.Name), p.ProfileID, start),
+		Attributes: gpuIdentityAttributes(v, migDeviceType, p.Name),
+		Capacity:   engineCapacity(p.Engines),
+		ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+			{CounterSet: counterSetName(gpuIndex), Counters: consumed},
+		},
+	}
+}
+
+// gpuIdentityAttributes returns the identity attributes common to whole-GPU and MIG devices.
+// profile is added only when non-empty (MIG devices). Runtime-only attributes (uuid,
+// driverVersion, cudaDriverVersion, pciBusID, pcieRoot, addressingMode, parentUUID) are
+// omitted — they cannot be known pre-scale.
+func gpuIdentityAttributes(v migVariant, deviceType, profile string) map[resourceapi.QualifiedName]resourceapi.DeviceAttribute {
+	attrs := map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+		"type": {StringValue: ptr.To(deviceType)},
+	}
+	if v.ProductName != "" {
+		attrs["productName"] = resourceapi.DeviceAttribute{StringValue: ptr.To(v.ProductName)}
+	}
+	if v.Brand != "" {
+		attrs["brand"] = resourceapi.DeviceAttribute{StringValue: ptr.To(v.Brand)}
+	}
+	if v.Architecture != "" {
+		attrs["architecture"] = resourceapi.DeviceAttribute{StringValue: ptr.To(v.Architecture)}
+	}
+	if v.CudaComputeCapability != "" {
+		attrs["cudaComputeCapability"] = resourceapi.DeviceAttribute{VersionValue: ptr.To(v.CudaComputeCapability)}
+	}
+	if profile != "" {
+		attrs[migProfileAttr] = resourceapi.DeviceAttribute{StringValue: ptr.To(profile)}
+	}
+	return attrs
+}
+
+// engineCountersHyphen builds the hyphenated counter map (CounterSet / ConsumesCounters).
+func engineCountersHyphen(e engineCounts) map[string]resourceapi.Counter {
+	return map[string]resourceapi.Counter{
+		ctrMultiprocessors: counterQty(e.Multiprocessors),
+		ctrCopyEngines:     counterQty(e.CopyEngines),
+		ctrDecoders:        counterQty(e.Decoders),
+		ctrEncoders:        counterQty(e.Encoders),
+		ctrJPEGEngines:     counterQty(e.JPEGEngines),
+		ctrOFAEngines:      counterQty(e.OFAEngines),
+		ctrMemory:          {Value: resource.MustParse(e.Memory)},
+	}
+}
+
+// engineCapacity builds the camelCase capacity map on a device.
+func engineCapacity(e engineCounts) map[resourceapi.QualifiedName]resourceapi.DeviceCapacity {
+	return map[resourceapi.QualifiedName]resourceapi.DeviceCapacity{
+		capMultiprocessors: {Value: *resource.NewQuantity(e.Multiprocessors, resource.DecimalSI)},
+		capCopyEngines:     {Value: *resource.NewQuantity(e.CopyEngines, resource.DecimalSI)},
+		capDecoders:        {Value: *resource.NewQuantity(e.Decoders, resource.DecimalSI)},
+		capEncoders:        {Value: *resource.NewQuantity(e.Encoders, resource.DecimalSI)},
+		capJPEGEngines:     {Value: *resource.NewQuantity(e.JPEGEngines, resource.DecimalSI)},
+		capOFAEngines:      {Value: *resource.NewQuantity(e.OFAEngines, resource.DecimalSI)},
+		capMemory:          {Value: resource.MustParse(e.Memory)},
+	}
+}
+
+func counterQty(n int64) resourceapi.Counter {
+	return resourceapi.Counter{Value: *resource.NewQuantity(n, resource.DecimalSI)}
+}
+
+// sanitizeProfileName turns a profile name like "1g.24gb" into a DNS-label-safe fragment
+// ("1g24gb") for use in the device name.
+func sanitizeProfileName(name string) string {
+	out := make([]rune, 0, len(name))
+	for _, r := range name {
+		if r == '.' {
+			continue
+		}
+		out = append(out, r)
+	}
+	return string(out)
+}

--- a/cluster-autoscaler/cloudprovider/aws/aws_dra_mig_allocator_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_dra_mig_allocator_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	resourceapi "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/dynamic-resource-allocation/cel"
+	"k8s.io/dynamic-resource-allocation/structured"
+)
+
+// fakeDeviceClassLister is a minimal structured.DeviceClassLister for tests that only
+// need a fixed, in-memory set of DeviceClasses.
+type fakeDeviceClassLister struct {
+	classes map[string]*resourceapi.DeviceClass
+}
+
+func (f *fakeDeviceClassLister) List() ([]*resourceapi.DeviceClass, error) {
+	classes := make([]*resourceapi.DeviceClass, 0, len(f.classes))
+	for _, c := range f.classes {
+		classes = append(classes, c)
+	}
+	return classes, nil
+}
+
+func (f *fakeDeviceClassLister) Get(className string) (*resourceapi.DeviceClass, error) {
+	class, ok := f.classes[className]
+	if !ok {
+		return nil, fmt.Errorf("class %s not found", className)
+	}
+	return class, nil
+}
+
+func migDeviceClass() *resourceapi.DeviceClass {
+	return &resourceapi.DeviceClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "mig.nvidia.com"},
+		Spec: resourceapi.DeviceClassSpec{
+			Selectors: []resourceapi.DeviceSelector{{
+				CEL: &resourceapi.CELDeviceSelector{
+					Expression: `device.driver == "gpu.nvidia.com" && device.attributes["gpu.nvidia.com"].type == "mig"`,
+				},
+			}},
+		},
+	}
+}
+
+func migClaim(name, profile string) *resourceapi.ResourceClaim {
+	return &resourceapi.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "test", UID: types.UID(name)},
+		Spec: resourceapi.ResourceClaimSpec{
+			Devices: resourceapi.DeviceClaim{
+				Requests: []resourceapi.DeviceRequest{{
+					Name: "mig-request",
+					Exactly: &resourceapi.ExactDeviceRequest{
+						DeviceClassName: "mig.nvidia.com",
+						AllocationMode:  resourceapi.DeviceAllocationModeExactCount,
+						Count:           1,
+						Selectors: []resourceapi.DeviceSelector{{
+							CEL: &resourceapi.CELDeviceSelector{
+								Expression: fmt.Sprintf(`device.attributes["gpu.nvidia.com"].profile == "%s"`, profile),
+							},
+						}},
+					},
+				}},
+			},
+		},
+	}
+}
+
+// TestMIGCounterConflictDetection exercises the real k8s.io/dynamic-resource-allocation
+// structured allocator (not our fabrication code) against our own fabricated MIG
+// ResourceSlices, proving that once a 1g.24gb partition is allocated, a conflicting
+// 4g.96gb (whole-GPU) claim requesting overlapping memory slices is correctly rejected.
+//
+// This is a regression test for a real upstream bug found while testing DRA scale-up
+// on a live cluster: k8s.io/dynamic-resource-allocation v0.34.2 (CA 1.34.x) tracked
+// partitionable-device counter consumption per-ResourceSlice instead of per-pool, so it
+// never detected this conflict when SharedCounters live in a separate slice from
+// Devices — the standard KEP-4815 shape both the real NVIDIA driver and
+// buildMIGResourceSlices use. Fixed upstream in v0.35.0 (kubernetes/kubernetes#134189),
+// which this branch (CA 1.35) vendors. This test would fail if run against v0.34.2.
+func TestMIGCounterConflictDetection(t *testing.T) {
+	node := draNode("test-node", map[string]string{
+		draDriverLabelKey:     "gpu.nvidia.com",
+		draMIGEnabledLabelKey: "true",
+	})
+	instanceType := &InstanceType{
+		InstanceType: "g7e.4xlarge",
+		GPU:          1,
+		GPUShortName: rtxPro6000ShortName,
+		GPUMemoryMiB: 98304,
+	}
+
+	slices := buildMIGResourceSlices(node, instanceType, "gpu.nvidia.com")
+	require.NotEmpty(t, slices)
+
+	// Simulate the 1g.24gb partition at placement 0 (gpu-0-mig-1g24gb-14-0) already
+	// being allocated to a held claim on the real node.
+	heldDevice := structured.MakeDeviceID("gpu.nvidia.com", node.Name, "gpu-0-mig-1g24gb-14-0")
+	allocatedState := structured.AllocatedState{
+		AllocatedDevices:         sets.New(heldDevice),
+		AllocatedSharedDeviceIDs: sets.New[structured.SharedDeviceID](),
+		AggregatedCapacity:       structured.NewConsumedCapacityCollection(),
+	}
+
+	classLister := &fakeDeviceClassLister{classes: map[string]*resourceapi.DeviceClass{
+		"mig.nvidia.com": migDeviceClass(),
+	}}
+
+	ctx := context.Background()
+	celCache := cel.NewCache(10, cel.Features{})
+
+	allocator, err := structured.NewAllocator(ctx, structured.Features{PartitionableDevices: true}, allocatedState, classLister, slices, celCache)
+	require.NoError(t, err)
+
+	conflicting := migClaim("conflicting-claim", "4g.96gb")
+	result, err := allocator.Allocate(ctx, node, []*resourceapi.ResourceClaim{conflicting})
+	require.NoError(t, err)
+	assert.Empty(t, result, "expected 4g.96gb to be rejected: it needs all 12 memory slices, which overlaps the already-allocated 1g.24gb partition's slices 0-2")
+
+	// Sanity check: the allocator isn't just rejecting everything. A non-overlapping
+	// 1g.24gb placement (e.g. slices 3-5, at a different offset than the held device)
+	// should still be allocatable.
+	nonConflicting := migClaim("non-conflicting-claim", "1g.24gb")
+	result2, err := allocator.Allocate(ctx, node, []*resourceapi.ResourceClaim{nonConflicting})
+	require.NoError(t, err)
+	assert.NotEmpty(t, result2, "expected a non-overlapping 1g.24gb placement to still be allocatable")
+}

--- a/cluster-autoscaler/cloudprovider/aws/aws_dra_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_dra_test.go
@@ -1,0 +1,294 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiv1 "k8s.io/api/core/v1"
+	resourceapi "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func draNode(name string, labels map[string]string) *apiv1.Node {
+	return &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels},
+	}
+}
+
+func TestBuildResourceSlicesFromTemplate_NonDRA(t *testing.T) {
+	tests := []struct {
+		name         string
+		labels       map[string]string
+		instanceType *InstanceType
+	}{
+		{
+			name:         "no dra-driver label returns nil",
+			labels:       map[string]string{},
+			instanceType: &InstanceType{InstanceType: "g5.xlarge", GPU: 1, GPUShortName: "A10G"},
+		},
+		{
+			name:         "dra-driver set but no GPU returns nil",
+			labels:       map[string]string{draDriverLabelKey: "gpu.nvidia.com"},
+			instanceType: &InstanceType{InstanceType: "m5.xlarge", GPU: 0},
+		},
+		{
+			name:         "nil instance type returns nil",
+			labels:       map[string]string{draDriverLabelKey: "gpu.nvidia.com"},
+			instanceType: nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildResourceSlicesFromTemplate(draNode("node-1", tc.labels), tc.instanceType)
+			assert.Nil(t, got)
+		})
+	}
+}
+
+func TestBuildResourceSlicesFromTemplate_FullGPU(t *testing.T) {
+	node := draNode("node-1", map[string]string{draDriverLabelKey: "gpu.nvidia.com"})
+	// g5.12xlarge has 4 A10G GPUs; the real driver emits one slice per GPU.
+	it := &InstanceType{InstanceType: "g5.12xlarge", GPU: 4, GPUShortName: "A10G", GPUMemoryMiB: 24576}
+
+	slices := buildResourceSlicesFromTemplate(node, it)
+
+	// One slice per GPU (verified from live AWS GPU nodes).
+	assert.Len(t, slices, 4, "one slice per GPU")
+	for i, slice := range slices {
+		assert.Equal(t, "gpu.nvidia.com", slice.Spec.Driver)
+		assert.Equal(t, "node-1", slice.Spec.Pool.Name)
+		if assert.NotNil(t, slice.Spec.NodeName) {
+			assert.Equal(t, "node-1", *slice.Spec.NodeName)
+		}
+		assert.Len(t, slice.Spec.Devices, 1, "one device per slice")
+		dev := slice.Spec.Devices[0]
+		assert.Equal(t, fmt.Sprintf("gpu-%d", i), dev.Name)
+	}
+
+	dev := slices[0].Spec.Devices[0]
+	// Rich attributes verified from live AWS g5 nodes.
+	assertStringAttr(t, dev, "type", "gpu")
+	assertStringAttr(t, dev, "productName", "NVIDIA A10G")
+	assertStringAttr(t, dev, "brand", "Nvidia") // driver reports "Nvidia", not "NVIDIA"
+	assertStringAttr(t, dev, "architecture", "Ampere")
+	if attr, ok := dev.Attributes["cudaComputeCapability"]; assert.True(t, ok) {
+		assert.Equal(t, "8.6.0", *attr.VersionValue)
+	}
+	if cap, ok := dev.Capacity["memory"]; assert.True(t, ok) {
+		// 24576Mi canonicalizes to 24Gi (same quantity).
+		assert.Equal(t, "24Gi", cap.Value.String())
+	}
+}
+
+// TestBuildResourceSlicesFromTemplate_FullGPU_MemoryOverride checks that a fullGPUAttrs entry
+// with MemoryMiB set overrides EC2's reported GPUMemoryMiB for the full-GPU device capacity —
+// the driver's actual published memory can be lower than EC2's nominal figure.
+func TestBuildResourceSlicesFromTemplate_FullGPU_MemoryOverride(t *testing.T) {
+	saved := gpuDataSource
+	defer func() { gpuDataSource = saved }()
+	gpuDataSource = fakeGPUDataSource{attrs: map[string]fullGPUAttrs{
+		"H200": {ProductName: "NVIDIA H200", Brand: "Nvidia", Architecture: "Hopper", MemoryMiB: 143771},
+	}}
+
+	node := draNode("node-1", map[string]string{draDriverLabelKey: "gpu.nvidia.com"})
+	it := &InstanceType{InstanceType: "p5e.48xlarge", GPU: 1, GPUShortName: "H200", GPUMemoryMiB: 144000}
+
+	slices := buildResourceSlicesFromTemplate(node, it)
+	require.Len(t, slices, 1)
+	cap, ok := slices[0].Spec.Devices[0].Capacity["memory"]
+	require.True(t, ok)
+	assert.Equal(t, "143771Mi", cap.Value.String(), "capacity should use the override, not EC2's nominal GPUMemoryMiB")
+}
+
+func TestBuildResourceSlicesFromTemplate_FullGPU_UnknownSKU(t *testing.T) {
+	node := draNode("node-1", map[string]string{draDriverLabelKey: "gpu.nvidia.com"})
+	it := &InstanceType{InstanceType: "gNext.xlarge", GPU: 1, GPUShortName: "B200", GPUMemoryMiB: 0}
+
+	slices := buildResourceSlicesFromTemplate(node, it)
+
+	assert.Len(t, slices, 1)
+	dev := slices[0].Spec.Devices[0]
+	// type is always present; richer attributes absent for an unmapped short name.
+	assertStringAttr(t, dev, "type", "gpu")
+	_, hasProduct := dev.Attributes["productName"]
+	assert.False(t, hasProduct, "unknown SKU should not carry productName")
+	assert.Nil(t, dev.Capacity, "no memory capacity when GPUMemoryMiB is unknown")
+}
+
+// TestBuildMIGResourceSlices_RTXPro6000 checks the structure against the values verified
+// from a real RTX PRO 6000 g7e node: 1 counters slice + 1 devices slice per GPU, each
+// device slice holding the whole-GPU device plus the plain MIG (profile x placement) set.
+func TestBuildMIGResourceSlices_RTXPro6000(t *testing.T) {
+	node := draNode("node-1", map[string]string{
+		draDriverLabelKey:     "gpu.nvidia.com",
+		draMIGEnabledLabelKey: "true",
+	})
+	it := &InstanceType{InstanceType: "g7e.12xlarge", GPU: 2, GPUShortName: rtxPro6000ShortName, GPUMemoryMiB: 98304}
+
+	slices := buildResourceSlicesFromTemplate(node, it)
+
+	// 1 counters slice + one devices slice per GPU (2) = 3.
+	assert.Len(t, slices, 3)
+	counters := slices[0]
+	assert.Len(t, counters.Spec.SharedCounters, 2, "one CounterSet per GPU")
+	assert.Empty(t, counters.Spec.Devices)
+	// Counter set carries the bulk memory counter and per-slice counters (12 slices).
+	cs := counters.Spec.SharedCounters[0].Counters
+	_, hasBulkMem := cs[ctrMemory]
+	assert.True(t, hasBulkMem, "counter set should have a bulk memory counter")
+	_, hasHyphenEngine := cs[ctrCopyEngines]
+	assert.True(t, hasHyphenEngine, "counter set uses hyphenated engine names")
+	assert.Contains(t, cs, memorySliceCounterPrefix+"11", "12 memory slices -> memory-slice-11 present")
+
+	for g, devicesSlice := range slices[1:] {
+		assert.Empty(t, devicesSlice.Spec.SharedCounters)
+		assert.Equal(t, "node-1", devicesSlice.Spec.Pool.Name)
+		// whole-GPU (1) + 1g.24gb (4) + 2g.48gb (2) + 4g.96gb (1) = 8 devices.
+		assert.Len(t, devicesSlice.Spec.Devices, 8, "GPU %d device count", g)
+
+		var sawWhole, saw1g bool
+		for _, d := range devicesSlice.Spec.Devices {
+			if profile, ok := d.Attributes[migProfileAttr]; ok {
+				assert.Equal(t, "mig", *d.Attributes["type"].StringValue, "MIG device %s type", d.Name)
+				// capacity uses camelCase, counters use hyphens.
+				_, hasCamelCap := d.Capacity[capCopyEngines]
+				assert.True(t, hasCamelCap, "device %s capacity uses camelCase", d.Name)
+				assert.Len(t, d.ConsumesCounters, 1)
+				if *profile.StringValue == "1g.24gb" {
+					saw1g = true
+				}
+			} else {
+				sawWhole = true
+				assert.Equal(t, "gpu", *d.Attributes["type"].StringValue, "whole-GPU device type")
+			}
+			// Identity attributes present on every device.
+			assertStringAttr(t, d, "productName", "NVIDIA RTX PRO 6000 Blackwell Server Edition")
+			assertStringAttr(t, d, "architecture", "Blackwell")
+		}
+		assert.True(t, sawWhole, "GPU %d missing whole-GPU device", g)
+		assert.True(t, saw1g, "GPU %d missing 1g.24gb MIG device", g)
+	}
+}
+
+// TestBuildMIGResourceSlices_A100Structure checks the (UNVERIFIED) A100 table produces a
+// well-formed slice set; values are placeholders pending a real capture.
+func TestBuildMIGResourceSlices_A100Structure(t *testing.T) {
+	node := draNode("node-1", map[string]string{
+		draDriverLabelKey:     "gpu.nvidia.com",
+		draMIGEnabledLabelKey: "true",
+	})
+	it := &InstanceType{InstanceType: "p4d.24xlarge", GPU: 1, GPUShortName: "A100", GPUMemoryMiB: 40960}
+
+	slices := buildResourceSlicesFromTemplate(node, it)
+	assert.Len(t, slices, 2, "1 counters + 1 devices slice for a single GPU")
+	// whole-GPU (1) + 1g.5gb (7) + 2g.10gb (3) + 3g.20gb (2) + 7g.40gb (1) = 14.
+	assert.Len(t, slices[1].Spec.Devices, 14)
+}
+
+// TestBuildMIGResourceSlices_DeviceChunking checks that a physical GPU whose MIG devices
+// exceed resourceapi.ResourceSliceMaxDevices gets split across multiple ResourceSlices instead
+// of producing a single oversized (API-invalid) slice, and that Pool.ResourceSliceCount agrees
+// with the actual number of slices produced.
+func TestBuildMIGResourceSlices_DeviceChunking(t *testing.T) {
+	saved := gpuDataSource
+	defer func() { gpuDataSource = saved }()
+
+	// 1 whole-GPU device + 150 placements of one profile = 151 devices for the single GPU,
+	// comfortably over the 128-device-per-slice API limit.
+	placements := make([]int, 150)
+	for i := range placements {
+		placements[i] = i
+	}
+	gpuDataSource = fakeGPUDataSource{migs: map[string][]migVariant{
+		"DenseGPU": {{
+			GPUMemoryMiB: 1000,
+			ProductName:  "Dense Test GPU",
+			Brand:        "Nvidia",
+			Architecture: "Test",
+			MemorySlices: 200,
+			Whole:        engineCounts{Memory: "1Gi"},
+			Profiles: []migProfile{
+				{Name: "1g.1gb", ProfileID: 0, MemorySlices: 1, Placements: placements, Engines: engineCounts{Memory: "1Mi"}},
+			},
+		}},
+	}}
+
+	node := draNode("node-1", map[string]string{
+		draDriverLabelKey:     "gpu.nvidia.com",
+		draMIGEnabledLabelKey: "true",
+	})
+	it := &InstanceType{InstanceType: "dense.xlarge", GPU: 1, GPUShortName: "DenseGPU", GPUMemoryMiB: 1000}
+
+	slices := buildResourceSlicesFromTemplate(node, it)
+	require.NotEmpty(t, slices)
+
+	// 1 counters slice + ceil(151/128) = 2 devices slices for the single GPU = 3.
+	require.Len(t, slices, 3)
+
+	totalDevices := 0
+	for _, s := range slices[1:] {
+		assert.LessOrEqual(t, len(s.Spec.Devices), resourceapi.ResourceSliceMaxDevices, "no slice should exceed the API device limit")
+		totalDevices += len(s.Spec.Devices)
+	}
+	assert.Equal(t, 151, totalDevices, "no devices should be dropped by chunking")
+
+	for _, s := range slices {
+		assert.Equal(t, int64(len(slices)), s.Spec.Pool.ResourceSliceCount, "every slice in the pool must agree on the total slice count")
+	}
+}
+
+func TestBuildMIGResourceSlices_UnknownSKU(t *testing.T) {
+	node := draNode("node-1", map[string]string{
+		draDriverLabelKey:     "gpu.nvidia.com",
+		draMIGEnabledLabelKey: "true",
+	})
+	// L4 has no MIG table -> no slices, so the node group won't falsely trigger scale-up.
+	it := &InstanceType{InstanceType: "g6.xlarge", GPU: 1, GPUShortName: "L4", GPUMemoryMiB: 24576}
+
+	slices := buildResourceSlicesFromTemplate(node, it)
+	assert.Nil(t, slices)
+}
+
+// TestBuildMIGResourceSlices_MemoryMismatch checks that a GPU whose EC2-reported per-device
+// memory doesn't closely match any ConfigMap variant for its short name fails safe (no
+// slices) instead of picking the nearest variant regardless of distance — picking, e.g., the
+// A100 fixture's 40GiB variant for an 80GiB instance would advertise the wrong profiles.
+func TestBuildMIGResourceSlices_MemoryMismatch(t *testing.T) {
+	node := draNode("node-1", map[string]string{
+		draDriverLabelKey:     "gpu.nvidia.com",
+		draMIGEnabledLabelKey: "true",
+	})
+	// testGPUDataSource's only A100 variant is 40960 MiB; 80000 is far outside tolerance.
+	it := &InstanceType{InstanceType: "p4de.24xlarge", GPU: 1, GPUShortName: "A100", GPUMemoryMiB: 80000}
+
+	slices := buildResourceSlicesFromTemplate(node, it)
+	assert.Nil(t, slices, "GPU memory too far from any known variant should not advertise MIG slices")
+}
+
+func assertStringAttr(t *testing.T, dev resourceapi.Device, key, want string) {
+	t.Helper()
+	attr, ok := dev.Attributes[resourceapi.QualifiedName(key)]
+	if assert.True(t, ok, "missing attribute %q", key) {
+		if assert.NotNil(t, attr.StringValue, "attribute %q has no string value", key) {
+			assert.Equal(t, want, *attr.StringValue)
+		}
+	}
+}

--- a/cluster-autoscaler/cloudprovider/aws/aws_util.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_util.go
@@ -71,6 +71,17 @@ func transformInstanceType(rawInstanceType *ec2types.InstanceTypeInfo) *Instance
 	}
 	if rawInstanceType.GpuInfo != nil && len(rawInstanceType.GpuInfo.Gpus) > 0 {
 		instanceType.GPU = int64(getGpuCount(rawInstanceType.GpuInfo))
+		// Capture per-device GPU metadata for building DRA ResourceSlices. EC2 only
+		// exposes the short name (e.g. "A10G", "H100") and per-device memory; richer
+		// attributes (product name, brand, architecture, CUDA compute capability) come
+		// from static maps keyed on GPUShortName in aws_dra.go.
+		gpuDevice := rawInstanceType.GpuInfo.Gpus[0]
+		if gpuDevice.Name != nil {
+			instanceType.GPUShortName = *gpuDevice.Name
+		}
+		if gpuDevice.MemoryInfo != nil && gpuDevice.MemoryInfo.SizeInMiB != nil {
+			instanceType.GPUMemoryMiB = int64(*gpuDevice.MemoryInfo.SizeInMiB)
+		}
 	}
 	if rawInstanceType.ProcessorInfo != nil && len(rawInstanceType.ProcessorInfo.SupportedArchitectures) > 0 {
 		instanceType.Architecture = interpretEc2SupportedArchitecure(string(rawInstanceType.ProcessorInfo.SupportedArchitectures[0]))

--- a/cluster-autoscaler/cloudprovider/aws/ec2_instance_types.go
+++ b/cluster-autoscaler/cloudprovider/aws/ec2_instance_types.go
@@ -19,11 +19,21 @@ limitations under the License.
 package aws
 
 // InstanceType is spec of EC2 instance
+//
+// [local] GPUShortName/GPUMemoryMiB are populated only via the dynamic path
+// (aws_util.go), not by gen.go. Regenerating this file via `go generate` will drop
+// both fields — re-add them here by hand afterward if needed.
 type InstanceType struct {
 	InstanceType string
 	VCPU         int64
 	MemoryMb     int64
 	GPU          int64
+	// GPUShortName is the EC2 GpuInfo.Gpus[0].Name (e.g. "A10G", "H100"), used as
+	// the key into the static GPU attribute maps when building DRA ResourceSlices.
+	GPUShortName string
+	// GPUMemoryMiB is the per-device GPU memory from EC2 GpuInfo, advertised as the
+	// "memory" capacity on DRA ResourceSlice devices.
+	GPUMemoryMiB int64
 	Architecture string
 }
 


### PR DESCRIPTION
Cluster Autoscaler cannot make correct scale-from-zero decisions for pods using DRA ResourceClaims (e.g. GPU requests via DRA), because TemplateNodeInfo() builds a template node with no ResourceSlices attached. This fabricates the ResourceSlices the NVIDIA DRA driver would publish once the node boots, derived from EC2 GPU metadata and GPU attribute data read from a ConfigMap (cluster-autoscaler-aws-dra-gpu-config) at runtime, so an operator can add a GPU model or fix a wrong MIG placement table by editing the ConfigMap, with no CA rebuild/redeploy.

